### PR TITLE
Refactor forms into smaller components

### DIFF
--- a/src/components/CustomerForm.tsx
+++ b/src/components/CustomerForm.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Customer, CustomerFormData, PincodeApiResponse, PostOffice } from '../types';
 import { useCrud } from '../context/CrudContext';
-import { Save, X, Loader2, Search } from 'lucide-react';
+import { Save, X, Loader2 } from 'lucide-react';
+import CustomerPersonalInfoSection from './customers/CustomerPersonalInfoSection';
+import CustomerShippingInfoSection from './customers/CustomerShippingInfoSection';
 
 interface CustomerFormProps {
   customer?: Customer | null; // For editing, null/undefined for creating
@@ -235,84 +237,25 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
             </div>
           )}
           
-          <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            <legend className="text-lg font-medium text-dark-text col-span-full">Personal Information</legend>
-            <div>
-              <label htmlFor="full_name" className={labelClass}>Full Name <span className="text-red-500">*</span></label>
-              <input type="text" name="full_name" id="full_name" value={formData.full_name} onChange={handleChange} className={inputClass} required />
-              {formErrors.full_name && <p className="text-xs text-red-500 mt-1">{formErrors.full_name}</p>}
-            </div>
-            <div>
-              <label htmlFor="email" className={labelClass}>Email</label>
-              <input type="email" name="email" id="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
-              {formErrors.email && <p className="text-xs text-red-500 mt-1">{formErrors.email}</p>}
-            </div>
-            <div>
-              <label htmlFor="mobile_number_1" className={labelClass}>Mobile Number 1</label>
-              <input type="tel" name="mobile_number_1" id="mobile_number_1" value={formData.mobile_number_1 || ''} onChange={handleChange} className={inputClass} />
-               {formErrors.mobile_number_1 && <p className="text-xs text-red-500 mt-1">{formErrors.mobile_number_1}</p>}
-            </div>
-            <div>
-              <label htmlFor="mobile_number_2" className={labelClass}>Mobile Number 2</label>
-              <input type="tel" name="mobile_number_2" id="mobile_number_2" value={formData.mobile_number_2 || ''} onChange={handleChange} className={inputClass} />
-            </div>
-             <div>
-              <label htmlFor="mobile_number_3" className={labelClass}>Mobile Number 3</label>
-              <input type="tel" name="mobile_number_3" id="mobile_number_3" value={formData.mobile_number_3 || ''} onChange={handleChange} className={inputClass} />
-            </div>
-          </fieldset>
+          <CustomerPersonalInfoSection
+            formData={formData}
+            formErrors={formErrors}
+            handleChange={handleChange}
+            inputClass={inputClass}
+            labelClass={labelClass}
+          />
 
-          <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
-            <legend className="text-lg font-medium text-dark-text col-span-full">Shipping Information</legend>
-            <div className="md:col-span-2">
-              <label htmlFor="shipping_address" className={labelClass}>Address Line</label>
-              <textarea name="shipping_address" id="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
-            </div>
-            
-            <div>
-              <label htmlFor="shipping_pincode" className={labelClass}>Pincode</label>
-              <div className="relative">
-                <input 
-                    type="text" 
-                    name="shipping_pincode" 
-                    id="shipping_pincode" 
-                    value={formData.shipping_pincode || ''} 
-                    onChange={handleChange} 
-                    className={inputClass} 
-                    maxLength={6}
-                />
-                {pincodeDetailsLoading && (
-                    <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                        <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-                    </div>
-                )}
-              </div>
-              {formErrors.shipping_pincode && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_pincode}</p>}
-              {pincodeError && <p className="text-xs text-red-500 mt-1">{pincodeError}</p>}
-            </div>
-
-            <div>
-              <label htmlFor="shipping_area" className={labelClass}>Area</label>
-              {isAreaSelect ? (
-                <select name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass}>
-                  <option value="">Select Area</option>
-                  {areaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-                </select>
-              ) : (
-                <input type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={areaOptions.length > 0 && !isAreaSelect} />
-              )}
-              {formErrors.shipping_area && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_area}</p>}
-            </div>
-
-            <div>
-              <label htmlFor="shipping_city" className={labelClass}>City</label>
-              <input type="text" name="shipping_city" id="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} className={inputClass} readOnly />
-            </div>
-            <div>
-              <label htmlFor="shipping_state" className={labelClass}>State</label>
-              <input type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
-            </div>
-          </fieldset>
+          <CustomerShippingInfoSection
+            formData={formData}
+            formErrors={formErrors}
+            handleChange={handleChange}
+            pincodeDetailsLoading={pincodeDetailsLoading}
+            pincodeError={pincodeError}
+            areaOptions={areaOptions}
+            isAreaSelect={isAreaSelect}
+            inputClass={inputClass}
+            labelClass={labelClass}
+          />
           
           <div className="flex justify-end items-center pt-4 border-t border-light-gray-200 mt-auto">
             <button

--- a/src/components/customers/CustomerPersonalInfoSection.tsx
+++ b/src/components/customers/CustomerPersonalInfoSection.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { CustomerFormData } from '../../types';
+
+interface Props {
+  formData: CustomerFormData;
+  formErrors: Partial<Record<keyof CustomerFormData, string>>;
+  handleChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+  inputClass: string;
+  labelClass: string;
+}
+
+const CustomerPersonalInfoSection: React.FC<Props> = ({ formData, formErrors, handleChange, inputClass, labelClass }) => (
+  <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <legend className="text-lg font-medium text-dark-text col-span-full">Personal Information</legend>
+    <div>
+      <label htmlFor="full_name" className={labelClass}>Full Name <span className="text-red-500">*</span></label>
+      <input type="text" name="full_name" id="full_name" value={formData.full_name} onChange={handleChange} className={inputClass} required />
+      {formErrors.full_name && <p className="text-xs text-red-500 mt-1">{formErrors.full_name}</p>}
+    </div>
+    <div>
+      <label htmlFor="email" className={labelClass}>Email</label>
+      <input type="email" name="email" id="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
+      {formErrors.email && <p className="text-xs text-red-500 mt-1">{formErrors.email}</p>}
+    </div>
+    <div>
+      <label htmlFor="mobile_number_1" className={labelClass}>Mobile Number 1</label>
+      <input type="tel" name="mobile_number_1" id="mobile_number_1" value={formData.mobile_number_1 || ''} onChange={handleChange} className={inputClass} />
+      {formErrors.mobile_number_1 && <p className="text-xs text-red-500 mt-1">{formErrors.mobile_number_1}</p>}
+    </div>
+    <div>
+      <label htmlFor="mobile_number_2" className={labelClass}>Mobile Number 2</label>
+      <input type="tel" name="mobile_number_2" id="mobile_number_2" value={formData.mobile_number_2 || ''} onChange={handleChange} className={inputClass} />
+    </div>
+    <div>
+      <label htmlFor="mobile_number_3" className={labelClass}>Mobile Number 3</label>
+      <input type="tel" name="mobile_number_3" id="mobile_number_3" value={formData.mobile_number_3 || ''} onChange={handleChange} className={inputClass} />
+    </div>
+  </fieldset>
+);
+
+export default CustomerPersonalInfoSection;

--- a/src/components/customers/CustomerShippingInfoSection.tsx
+++ b/src/components/customers/CustomerShippingInfoSection.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { CustomerFormData } from '../../types';
+import { Loader2 } from 'lucide-react';
+
+interface AreaOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  formData: CustomerFormData;
+  formErrors: Partial<Record<keyof CustomerFormData, string>>;
+  handleChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+  pincodeDetailsLoading: boolean;
+  pincodeError: string | null;
+  areaOptions: AreaOption[];
+  isAreaSelect: boolean;
+  inputClass: string;
+  labelClass: string;
+}
+
+const CustomerShippingInfoSection: React.FC<Props> = ({
+  formData,
+  formErrors,
+  handleChange,
+  pincodeDetailsLoading,
+  pincodeError,
+  areaOptions,
+  isAreaSelect,
+  inputClass,
+  labelClass,
+}) => (
+  <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <legend className="text-lg font-medium text-dark-text col-span-full">Shipping Information</legend>
+    <div className="md:col-span-2">
+      <label htmlFor="shipping_address" className={labelClass}>Address Line</label>
+      <textarea name="shipping_address" id="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
+    </div>
+
+    <div>
+      <label htmlFor="shipping_pincode" className={labelClass}>Pincode</label>
+      <div className="relative">
+        <input
+          type="text"
+          name="shipping_pincode"
+          id="shipping_pincode"
+          value={formData.shipping_pincode || ''}
+          onChange={handleChange}
+          className={inputClass}
+          maxLength={6}
+        />
+        {pincodeDetailsLoading && (
+          <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+            <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+          </div>
+        )}
+      </div>
+      {formErrors.shipping_pincode && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_pincode}</p>}
+      {pincodeError && <p className="text-xs text-red-500 mt-1">{pincodeError}</p>}
+    </div>
+
+    <div>
+      <label htmlFor="shipping_area" className={labelClass}>Area</label>
+      {isAreaSelect ? (
+        <select name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass}>
+          <option value="">Select Area</option>
+          {areaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+        </select>
+      ) : (
+        <input type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={areaOptions.length > 0 && !isAreaSelect} />
+      )}
+      {formErrors.shipping_area && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_area}</p>}
+    </div>
+
+    <div>
+      <label htmlFor="shipping_city" className={labelClass}>City</label>
+      <input type="text" name="shipping_city" id="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} className={inputClass} readOnly />
+    </div>
+    <div>
+      <label htmlFor="shipping_state" className={labelClass}>State</label>
+      <input type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
+    </div>
+  </fieldset>
+);
+
+export default CustomerShippingInfoSection;

--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { RentalItemFormData, Equipment as EquipmentType } from '../../types';
+import { Trash2, PackagePlus } from 'lucide-react';
+import { formatCurrency } from '../../utils/formatting';
+
+interface Props {
+  items: RentalItemFormData[];
+  formErrors: Record<string, string>;
+  availableEquipment: EquipmentType[];
+  loadingEquipment: boolean;
+  handleItemChange: (index: number, field: keyof RentalItemFormData, value: string) => void;
+  removeItem: (index: number) => void;
+  addItem: () => void;
+  inputClass: string;
+  labelClass: string;
+}
+
+const RentalItemsSection: React.FC<Props> = ({
+  items,
+  formErrors,
+  availableEquipment,
+  loadingEquipment,
+  handleItemChange,
+  removeItem,
+  addItem,
+  inputClass,
+  labelClass,
+}) => (
+  <fieldset>
+    <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Rental Items</legend>
+    {formErrors.rental_items && typeof formErrors.rental_items !== 'object' && (
+      <p className="text-xs text-red-500 mb-2">{formErrors.rental_items}</p>
+    )}
+    <div className="space-y-4 max-h-60 overflow-y-auto pr-2">
+      {items.map((item, index) => (
+        <div key={item.temp_id} className="p-4 border border-light-gray-200 rounded-md space-y-3 bg-light-gray-50 relative">
+          <button
+            type="button"
+            onClick={() => removeItem(index)}
+            className="absolute top-2 right-2 p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
+            title="Remove Item"
+          >
+            <Trash2 size={16} />
+          </button>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <div className="md:col-span-2">
+              <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
+              <select
+                id={`item_equipment_${index}`}
+                value={item.equipment_id}
+                onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
+                className={`${inputClass} text-xs py-1.5`}
+                disabled={loadingEquipment}
+              >
+                <option value="">{loadingEquipment ? 'Loading...' : 'Select Equipment'}</option>
+                {availableEquipment.map((eq) => (
+                  <option key={eq.equipment_id} value={String(eq.equipment_id)}>
+                    {eq.equipment_name} (SN: {eq.serial_number || 'N/A'}) - Rate: {formatCurrency(eq.rental_rate)}
+                  </option>
+                ))}
+              </select>
+              {formErrors[`rental_items.${index}.equipment_id`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>}
+            </div>
+            <div>
+              <label htmlFor={`item_quantity_${index}`} className={`${labelClass} text-xs`}>Quantity <span className="text-red-500">*</span></label>
+              <input
+                type="number"
+                id={`item_quantity_${index}`}
+                value={item.quantity}
+                onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
+                className={`${inputClass} text-xs py-1.5`}
+                min="1"
+              />
+               {formErrors[`rental_items.${index}.quantity`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.quantity`]}</p>}
+            </div>
+            <div>
+              <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
+              <input
+                type="number"
+                id={`item_rate_${index}`}
+                value={item.unit_rental_rate}
+                onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
+                className={`${inputClass} text-xs py-1.5`}
+                step="0.01"
+                min="0"
+                placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
+              />
+               {formErrors[`rental_items.${index}.unit_rental_rate`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+    <button
+      type="button"
+      onClick={addItem}
+      className="mt-3 inline-flex items-center px-3 py-1.5 border border-dashed border-brand-blue text-brand-blue text-xs font-medium rounded-md hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-brand-blue"
+    >
+      <PackagePlus size={16} className="mr-2" /> Add Rental Item
+    </button>
+  </fieldset>
+);
+
+export default RentalItemsSection;

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -20,12 +20,11 @@ import {
   IndianRupee,
   ListChecks,
   Info,
-  PackagePlus,
-  Trash2,
   ChevronDown,
   DollarSign,
   CalendarDays,
 } from 'lucide-react';
+import RentalItemsSection from './RentalItemsSection';
 import { formatCurrency } from '../../utils/formatting'; // Import formatCurrency
 
 const RENTAL_STATUSES_FORM = ["Draft", "Pending Confirmation", "Confirmed/Booked", "Active/Rented Out", "Returned/Completed", "Overdue", "Cancelled"];
@@ -322,77 +321,17 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             </div>
           </fieldset>
 
-          <fieldset>
-            <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Rental Items</legend>
-            {formErrors.rental_items && !Array.isArray(formErrors.rental_items) && <p className="text-xs text-red-500 mb-2">{formErrors.rental_items}</p>}
-            <div className="space-y-4 max-h-60 overflow-y-auto pr-2">
-              {formData.rental_items.map((item, index) => (
-                <div key={item.temp_id} className="p-4 border border-light-gray-200 rounded-md space-y-3 bg-light-gray-50 relative">
-                  <button
-                    type="button"
-                    onClick={() => removeItem(index)}
-                    className="absolute top-2 right-2 p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
-                    title="Remove Item"
-                  >
-                    <Trash2 size={16} />
-                  </button>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    <div className="md:col-span-2">
-                      <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
-                      <select
-                        id={`item_equipment_${index}`}
-                        value={item.equipment_id}
-                        onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
-                        className={`${inputClass} text-xs py-1.5`}
-                        disabled={loadingEquipment}
-                      >
-                        <option value="">{loadingEquipment ? "Loading..." : "Select Equipment"}</option>
-                        {availableEquipment.map((eq: EquipmentType) => (
-                          <option key={eq.equipment_id} value={String(eq.equipment_id)}>
-                            {eq.equipment_name} (SN: {eq.serial_number || 'N/A'}) - Rate: {formatCurrency(eq.rental_rate)}
-                          </option>
-                        ))}
-                      </select>
-                      {formErrors[`rental_items.${index}.equipment_id`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>}
-                    </div>
-                    <div>
-                      <label htmlFor={`item_quantity_${index}`} className={`${labelClass} text-xs`}>Quantity <span className="text-red-500">*</span></label>
-                      <input
-                        type="number"
-                        id={`item_quantity_${index}`}
-                        value={item.quantity}
-                        onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
-                        className={`${inputClass} text-xs py-1.5`}
-                        min="1"
-                      />
-                       {formErrors[`rental_items.${index}.quantity`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.quantity`]}</p>}
-                    </div>
-                    <div>
-                      <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
-                      <input
-                        type="number"
-                        id={`item_rate_${index}`}
-                        value={item.unit_rental_rate}
-                        onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
-                        className={`${inputClass} text-xs py-1.5`}
-                        step="0.01"
-                        min="0"
-                        placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : "0.00"}
-                      />
-                       {formErrors[`rental_items.${index}.unit_rental_rate`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={addItem}
-              className="mt-3 inline-flex items-center px-3 py-1.5 border border-dashed border-brand-blue text-brand-blue text-xs font-medium rounded-md hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-brand-blue"
-            >
-              <PackagePlus size={16} className="mr-2" /> Add Rental Item
-            </button>
-          </fieldset>
+          <RentalItemsSection
+            items={formData.rental_items}
+            formErrors={formErrors as Record<string, string>}
+            availableEquipment={availableEquipment}
+            loadingEquipment={loadingEquipment}
+            handleItemChange={handleItemChange}
+            removeItem={removeItem}
+            addItem={addItem}
+            inputClass={inputClass}
+            labelClass={labelClass}
+          />
 
           <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
             <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Payment & Notes</legend>


### PR DESCRIPTION
## Summary
- extract customer personal & shipping sections into new subcomponents
- split rental items UI into its own component
- update forms to use the new components

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_684017dbd1b48321ade933852b13a2d6