### PR TITLE
Create reusable form field components

### DIFF
--- a/src/components/CustomerForm.tsx
+++ b/src/components/CustomerForm.tsx
@@ -215,7 +215,6 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
   }, [formData.shipping_pincode, debouncedFetchPincodeDetails]);
 
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm";
   const labelClass = "block text-sm font-medium text-dark-text";
 
   return (
@@ -236,7 +235,6 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
             formData={formData}
             formErrors={formErrors}
             handleChange={handleChange}
-            inputClass={inputClass}
             labelClass={labelClass}
           />
 
@@ -248,7 +246,6 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
             pincodeError={pincodeError}
             areaOptions={areaOptions}
             isAreaSelect={isAreaSelect}
-            inputClass={inputClass}
             labelClass={labelClass}
           />
           

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -4,6 +4,7 @@ import { useCrud } from '../context/CrudContext';
 import { useEquipmentCategories } from '../context/EquipmentCategoryContext'; 
 import { Save, X, Loader2, Package, Tag, Hash, CalendarDays, MapPin, Info, Wrench, Layers, IndianRupee } from 'lucide-react'; // Changed DollarSign to IndianRupee
 import Modal from './ui/Modal';
+import { TextField, TextAreaField, SelectField } from './ui/FormField';
 
 interface EquipmentFormProps {
   equipment?: Equipment | null;
@@ -164,7 +165,6 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
     }
   };
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm disabled:bg-light-gray-100";
   const labelClass = "block text-sm font-medium text-dark-text";
   const iconClass = "h-5 w-5 text-gray-400 mr-2";
 
@@ -199,7 +199,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
               <label htmlFor="equipment_name" className={labelClass}>Equipment Name <span className="text-red-500">*</span></label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Package className={iconClass} /></div>
-                <input type="text" name="equipment_name" id="equipment_name" value={formData.equipment_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
+                <TextField type="text" name="equipment_name" id="equipment_name" value={formData.equipment_name} onChange={handleChange} className="pl-10" required />
               </div>
               {formErrors.equipment_name && <p className="text-xs text-red-500 mt-1">{formErrors.equipment_name}</p>}
             </div>
@@ -208,7 +208,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
               <label htmlFor="description" className={labelClass}>Description</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={3} className={`${inputClass} pl-10`}></textarea>
+                <TextAreaField name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={3} className="pl-10" />
               </div>
             </div>
 
@@ -218,17 +218,17 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                     {categoriesLoading ? <Loader2 className={`${iconClass} animate-spin`} /> : <Tag className={iconClass} />}
                 </div>
-                <select 
-                    name="category_id" 
-                    id="category_id" 
-                    value={formData.category_id === undefined ? '' : String(formData.category_id)} 
-                    onChange={handleChange} 
-                    className={`${inputClass} pl-10`}
+                <SelectField
+                    name="category_id"
+                    id="category_id"
+                    value={formData.category_id === undefined ? '' : String(formData.category_id)}
+                    onChange={handleChange}
+                    className="pl-10"
                     disabled={categoriesLoading || !!categoriesError}
                 >
                     <option value="">{categoriesLoading ? 'Loading...' : 'Select Category'}</option>
                     {equipmentCategories.map(cat => <option key={cat.category_id} value={String(cat.category_id)}>{cat.category_name}</option>)}
-                </select>
+                </SelectField>
               </div>
             </div>
 
@@ -236,9 +236,9 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
               <label htmlFor="status" className={labelClass}>Status</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Tag className={iconClass} /></div>
-                <select name="status" id="status" value={formData.status || ''} onChange={handleChange} className={`${inputClass} pl-10`}>
+                <SelectField name="status" id="status" value={formData.status || ''} onChange={handleChange} className="pl-10">
                     {equipmentStatuses.map(s => <option key={s} value={s}>{s}</option>)}
-                </select>
+                </SelectField>
               </div>
             </div>
           </fieldset>
@@ -247,17 +247,17 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
             <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Identification, Quantity & Financials</legend>
             <div>
               <label htmlFor="make" className={labelClass}>Make/Brand</label>
-              <input type="text" name="make" id="make" value={formData.make || ''} onChange={handleChange} className={inputClass} />
+              <TextField type="text" name="make" id="make" value={formData.make || ''} onChange={handleChange} />
             </div>
             <div>
               <label htmlFor="model" className={labelClass}>Model</label>
-              <input type="text" name="model" id="model" value={formData.model || ''} onChange={handleChange} className={inputClass} />
+              <TextField type="text" name="model" id="model" value={formData.model || ''} onChange={handleChange} />
             </div>
             <div>
               <label htmlFor="serial_number" className={labelClass}>Serial Number {isEditing ? '(Editing specific item)' : '(Base for quantity)'}</label>
                <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Hash className={iconClass} /></div>
-                <input type="text" name="serial_number" id="serial_number" value={formData.serial_number || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+                <TextField type="text" name="serial_number" id="serial_number" value={formData.serial_number || ''} onChange={handleChange} className="pl-10" />
               </div>
               {formErrors.serial_number && <p className="text-xs text-red-500 mt-1">{formErrors.serial_number}</p>}
             </div>
@@ -267,7 +267,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
                     <label htmlFor="quantity" className={labelClass}>Quantity</label>
                     <div className="mt-1 relative rounded-md shadow-sm">
                         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Layers className={iconClass}/></div>
-                        <input type="number" name="quantity" id="quantity" value={formData.quantity || '1'} onChange={handleChange} className={`${inputClass} pl-10`} min="1" />
+                        <TextField type="number" name="quantity" id="quantity" value={formData.quantity || '1'} onChange={handleChange} className="pl-10" min="1" />
                     </div>
                     {formErrors.quantity && <p className="text-xs text-red-500 mt-1">{formErrors.quantity}</p>}
                 </div>
@@ -278,7 +278,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
               <label htmlFor="rental_rate" className={labelClass}>Rental Rate (₹ per unit/day)</label> 
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><IndianRupee className={iconClass} /></div> {/* Changed icon */}
-                <input type="number" name="rental_rate" id="rental_rate" value={formData.rental_rate || ''} onChange={handleChange} className={`${inputClass} pl-10`} step="0.01" min="0"/>
+                <TextField type="number" name="rental_rate" id="rental_rate" value={formData.rental_rate || ''} onChange={handleChange} className="pl-10" step="0.01" min="0"/>
               </div>
               {formErrors.rental_rate && <p className="text-xs text-red-500 mt-1">{formErrors.rental_rate}</p>}
             </div>
@@ -288,28 +288,28 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
             <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Dates & Location</legend>
             <div>
               <label htmlFor="purchase_date" className={labelClass}>Purchase Date</label>
-              <input type="date" name="purchase_date" id="purchase_date" value={formData.purchase_date || ''} onChange={handleChange} className={inputClass} />
+              <TextField type="date" name="purchase_date" id="purchase_date" value={formData.purchase_date || ''} onChange={handleChange} />
                {formErrors.purchase_date && <p className="text-xs text-red-500 mt-1">{formErrors.purchase_date}</p>}
             </div>
             <div>
               <label htmlFor="location" className={labelClass}>Current Location</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><MapPin className={iconClass} /></div>
-                <input type="text" name="location" id="location" value={formData.location || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+                <TextField type="text" name="location" id="location" value={formData.location || ''} onChange={handleChange} className="pl-10" />
               </div>
             </div>
             <div>
               <label htmlFor="last_maintenance_date" className={labelClass}>Last Maintenance Date</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Wrench className={iconClass} /></div>
-                <input type="date" name="last_maintenance_date" id="last_maintenance_date" value={formData.last_maintenance_date || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+                <TextField type="date" name="last_maintenance_date" id="last_maintenance_date" value={formData.last_maintenance_date || ''} onChange={handleChange} className="pl-10" />
               </div>
             </div>
             <div>
               <label htmlFor="next_calibration_date" className={labelClass}>Next Calibration Date</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><CalendarDays className={iconClass} /></div>
-                <input type="date" name="next_calibration_date" id="next_calibration_date" value={formData.next_calibration_date || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+                <TextField type="date" name="next_calibration_date" id="next_calibration_date" value={formData.next_calibration_date || ''} onChange={handleChange} className="pl-10" />
               </div>
             </div>
           </fieldset>

--- a/src/components/MaintenanceRecordForm.tsx
+++ b/src/components/MaintenanceRecordForm.tsx
@@ -7,6 +7,7 @@ import { useMaintenanceRecords } from '../context/MaintenanceRecordContext'; // 
 import { useCrud } from '../context/CrudContext'; // To get loading state from CRUD operations
 import { Save, X, Loader2, Package, CalendarDays, Wrench, User, IndianRupee, Info, ChevronDown } from 'lucide-react';
 import Modal from './ui/Modal';
+import { TextField, TextAreaField, SelectField } from './ui/FormField';
 
 interface MaintenanceRecordFormProps {
   record?: MaintenanceRecordFormData; // For editing
@@ -157,7 +158,6 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
     onSave(formData);
   };
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm disabled:bg-light-gray-100";
   const labelClass = "block text-sm font-medium text-dark-text";
   const iconClass = "h-5 w-5 text-gray-400";
 
@@ -187,14 +187,14 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   {loadingEquipmentList ? <Loader2 className={`${iconClass} animate-spin`} /> : <Package className={iconClass} />}
                 </div>
-                <select
+                <SelectField
                   id="equipment_id"
                   name="equipment_id"
                   value={formData.equipment_id}
                   onChange={handleGenericChange} // Correctly uses the updated handleGenericChange
                   required
                   disabled={loadingEquipmentList}
-                  className={`${inputClass} pl-10`}
+                  className="pl-10"
                 >
                   <option value="">{loadingEquipmentList ? 'Loading Equipment...' : 'Select Equipment'}</option>
                   {!loadingEquipmentList && equipmentListForFilter.map(equipment => (
@@ -202,7 +202,7 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
                       {equipment.equipment_name} ({equipment.serial_number || 'N/A'})
                     </option>
                   ))}
-                </select>
+                </SelectField>
               </div>
               {formErrors.equipment_id && <p className="text-xs text-red-500 mt-1">{formErrors.equipment_id}</p>}
             </div>
@@ -211,14 +211,14 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="maintenance_date" className={labelClass}>Maintenance Date <span className="text-red-500">*</span></label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><CalendarDays className={iconClass} /></div>
-                <input
+                <TextField
                   type="date"
                   id="maintenance_date"
                   name="maintenance_date"
                   value={formData.maintenance_date}
                   onChange={handleGenericChange}
                   required
-                  className={`${inputClass} pl-10`}
+                  className="pl-10"
                 />
               </div>
               {formErrors.maintenance_date && <p className="text-xs text-red-500 mt-1">{formErrors.maintenance_date}</p>}
@@ -229,19 +229,19 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="maintenance_type_dropdown" className={labelClass}>Maintenance Type</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Wrench className={iconClass} /></div>
-                <select
+                <SelectField
                   id="maintenance_type_dropdown"
                   name="maintenance_type_dropdown"
                   value={selectedDropdownMaintenanceType}
                   onChange={handleDropdownChange} // Specific handler for this dropdown
-                  className={`${inputClass} pl-10 pr-8 appearance-none`}
+                  className="pl-10 pr-8 appearance-none"
                 >
                   <option value="">Select Type...</option>
                   {PREDEFINED_MAINTENANCE_TYPES.map(type => (
                     <option key={type} value={type}>{type}</option>
                   ))}
                   <option value={CUSTOM_MAINTENANCE_TYPE_KEY}>Other (Specify)</option>
-                </select>
+                </SelectField>
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
                     <ChevronDown className="h-4 w-4 text-gray-400" />
                 </div>
@@ -252,14 +252,14 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               {selectedDropdownMaintenanceType === CUSTOM_MAINTENANCE_TYPE_KEY && (
                 <div className="mt-2">
                   <label htmlFor="custom_maintenance_type" className={`${labelClass} text-xs`}>Specify Other Type:</label>
-                  <input
+                  <TextField
                     type="text"
                     id="custom_maintenance_type"
                     name="custom_maintenance_type"
                     value={customMaintenanceTypeValue}
                     onChange={handleCustomInputChange} // Specific handler
                     placeholder="Enter custom maintenance type"
-                    className={`${inputClass} pl-3`}
+                    className="pl-3"
                   />
                    {formErrors.maintenance_type && <p className="text-xs text-red-500 mt-1">{formErrors.maintenance_type}</p>}
                 </div>
@@ -271,13 +271,13 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="technician" className={labelClass}>Technician</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><User className={iconClass} /></div>
-                <input
+                <TextField
                   type="text"
                   id="technician"
                   name="technician"
                   value={formData.technician || ''}
                   onChange={handleGenericChange}
-                  className={`${inputClass} pl-10`}
+                  className="pl-10"
                 />
               </div>
             </div>
@@ -286,7 +286,7 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="cost" className={labelClass}>Cost (₹)</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><IndianRupee className={iconClass} /></div>
-                <input
+                <TextField
                   type="number"
                   id="cost"
                   name="cost"
@@ -295,7 +295,7 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
                   step="0.01"
                   min="0"
                   placeholder="0.00"
-                  className={`${inputClass} pl-10`}
+                  className="pl-10"
                 />
               </div>
               {formErrors.cost && <p className="text-xs text-red-500 mt-1">{formErrors.cost}</p>}
@@ -305,14 +305,14 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="notes" className={labelClass}>Notes</label>
                <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea
+                <TextAreaField
                     id="notes"
                     name="notes"
                     value={formData.notes || ''}
                     onChange={handleGenericChange}
                     rows={3}
-                    className={`${inputClass} pl-10`}
-                ></textarea>
+                    className="pl-10"
+                />
               </div>
             </div>
           </fieldset>

--- a/src/components/customers/CustomerPersonalInfoSection.tsx
+++ b/src/components/customers/CustomerPersonalInfoSection.tsx
@@ -1,39 +1,39 @@
 import React from 'react';
 import { CustomerFormData } from '../../types';
+import { TextField } from '../ui/FormField';
 
 interface Props {
   formData: CustomerFormData;
   formErrors: Partial<Record<keyof CustomerFormData, string>>;
   handleChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
-  inputClass: string;
   labelClass: string;
 }
 
-const CustomerPersonalInfoSection: React.FC<Props> = ({ formData, formErrors, handleChange, inputClass, labelClass }) => (
+const CustomerPersonalInfoSection: React.FC<Props> = ({ formData, formErrors, handleChange, labelClass }) => (
   <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full">Personal Information</legend>
     <div>
       <label htmlFor="full_name" className={labelClass}>Full Name <span className="text-red-500">*</span></label>
-      <input type="text" name="full_name" id="full_name" value={formData.full_name} onChange={handleChange} className={inputClass} required />
+      <TextField type="text" name="full_name" id="full_name" value={formData.full_name} onChange={handleChange} required />
       {formErrors.full_name && <p className="text-xs text-red-500 mt-1">{formErrors.full_name}</p>}
     </div>
     <div>
       <label htmlFor="email" className={labelClass}>Email</label>
-      <input type="email" name="email" id="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
+      <TextField type="email" name="email" id="email" value={formData.email || ''} onChange={handleChange} />
       {formErrors.email && <p className="text-xs text-red-500 mt-1">{formErrors.email}</p>}
     </div>
     <div>
       <label htmlFor="mobile_number_1" className={labelClass}>Mobile Number 1</label>
-      <input type="tel" name="mobile_number_1" id="mobile_number_1" value={formData.mobile_number_1 || ''} onChange={handleChange} className={inputClass} />
+      <TextField type="tel" name="mobile_number_1" id="mobile_number_1" value={formData.mobile_number_1 || ''} onChange={handleChange} />
       {formErrors.mobile_number_1 && <p className="text-xs text-red-500 mt-1">{formErrors.mobile_number_1}</p>}
     </div>
     <div>
       <label htmlFor="mobile_number_2" className={labelClass}>Mobile Number 2</label>
-      <input type="tel" name="mobile_number_2" id="mobile_number_2" value={formData.mobile_number_2 || ''} onChange={handleChange} className={inputClass} />
+      <TextField type="tel" name="mobile_number_2" id="mobile_number_2" value={formData.mobile_number_2 || ''} onChange={handleChange} />
     </div>
     <div>
       <label htmlFor="mobile_number_3" className={labelClass}>Mobile Number 3</label>
-      <input type="tel" name="mobile_number_3" id="mobile_number_3" value={formData.mobile_number_3 || ''} onChange={handleChange} className={inputClass} />
+      <TextField type="tel" name="mobile_number_3" id="mobile_number_3" value={formData.mobile_number_3 || ''} onChange={handleChange} />
     </div>
   </fieldset>
 );

--- a/src/components/customers/CustomerShippingInfoSection.tsx
+++ b/src/components/customers/CustomerShippingInfoSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CustomerFormData } from '../../types';
 import { Loader2 } from 'lucide-react';
+import { TextField, TextAreaField, SelectField } from '../ui/FormField';
 
 interface AreaOption {
   value: string;
@@ -15,7 +16,6 @@ interface Props {
   pincodeError: string | null;
   areaOptions: AreaOption[];
   isAreaSelect: boolean;
-  inputClass: string;
   labelClass: string;
 }
 
@@ -27,26 +27,24 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
   pincodeError,
   areaOptions,
   isAreaSelect,
-  inputClass,
   labelClass,
 }) => (
   <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full">Shipping Information</legend>
     <div className="md:col-span-2">
       <label htmlFor="shipping_address" className={labelClass}>Address Line</label>
-      <textarea name="shipping_address" id="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
+      <TextAreaField name="shipping_address" id="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} />
     </div>
 
     <div>
       <label htmlFor="shipping_pincode" className={labelClass}>Pincode</label>
       <div className="relative">
-        <input
+        <TextField
           type="text"
           name="shipping_pincode"
           id="shipping_pincode"
           value={formData.shipping_pincode || ''}
           onChange={handleChange}
-          className={inputClass}
           maxLength={6}
         />
         {pincodeDetailsLoading && (
@@ -62,23 +60,23 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
     <div>
       <label htmlFor="shipping_area" className={labelClass}>Area</label>
       {isAreaSelect ? (
-        <select name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass}>
+        <SelectField name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange}>
           <option value="">Select Area</option>
           {areaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-        </select>
+        </SelectField>
       ) : (
-        <input type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={areaOptions.length > 0 && !isAreaSelect} />
+        <TextField type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} readOnly={areaOptions.length > 0 && !isAreaSelect} />
       )}
       {formErrors.shipping_area && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_area}</p>}
     </div>
 
     <div>
       <label htmlFor="shipping_city" className={labelClass}>City</label>
-      <input type="text" name="shipping_city" id="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} className={inputClass} readOnly />
+      <TextField type="text" name="shipping_city" id="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} readOnly />
     </div>
     <div>
       <label htmlFor="shipping_state" className={labelClass}>State</label>
-      <input type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
+      <TextField type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} readOnly />
     </div>
   </fieldset>
 );

--- a/src/components/masters/EquipmentCategoryForm.tsx
+++ b/src/components/masters/EquipmentCategoryForm.tsx
@@ -3,6 +3,7 @@ import { EquipmentCategory, EquipmentCategoryFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, Tag, Info } from 'lucide-react';
 import Modal from '../ui/Modal';
+import { TextField, TextAreaField } from '../ui/FormField';
 
 interface EquipmentCategoryFormProps {
   category?: EquipmentCategory | null;
@@ -72,7 +73,6 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
     }
   };
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm";
   const labelClass = "block text-sm font-medium text-dark-text";
   const iconClass = "h-5 w-5 text-gray-400";
 
@@ -100,7 +100,7 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
             <label htmlFor="category_name" className={labelClass}>Category Name <span className="text-red-500">*</span></label>
             <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Tag className={iconClass} /></div>
-                <input type="text" name="category_name" id="category_name" value={formData.category_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
+                <TextField type="text" name="category_name" id="category_name" value={formData.category_name} onChange={handleChange} className="pl-10" required />
             </div>
             {formErrors.category_name && <p className="text-xs text-red-500 mt-1">{formErrors.category_name}</p>}
           </div>
@@ -109,7 +109,7 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
             <label htmlFor="description" className={labelClass}>Description</label>
             <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className={`${inputClass} pl-10`}></textarea>
+                <TextAreaField name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className="pl-10" />
             </div>
           </div>
 

--- a/src/components/masters/PaymentPlanForm.tsx
+++ b/src/components/masters/PaymentPlanForm.tsx
@@ -3,6 +3,7 @@ import { PaymentPlan, PaymentPlanFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, ListChecks, Info, CalendarClock } from 'lucide-react';
 import Modal from '../ui/Modal';
+import { TextField, TextAreaField } from '../ui/FormField';
 
 interface PaymentPlanFormProps {
   plan?: PaymentPlan | null;
@@ -85,7 +86,6 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
     }
   };
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm";
   const labelClass = "block text-sm font-medium text-dark-text";
   const iconClass = "h-5 w-5 text-gray-400";
 
@@ -112,7 +112,7 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
             <label htmlFor="plan_name" className={labelClass}>Plan Name <span className="text-red-500">*</span></label>
              <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><ListChecks className={iconClass} /></div>
-                <input type="text" name="plan_name" id="plan_name" value={formData.plan_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
+                <TextField type="text" name="plan_name" id="plan_name" value={formData.plan_name} onChange={handleChange} className="pl-10" required />
             </div>
             {formErrors.plan_name && <p className="text-xs text-red-500 mt-1">{formErrors.plan_name}</p>}
           </div>
@@ -121,7 +121,7 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
             <label htmlFor="frequency_in_days" className={labelClass}>Frequency (in days)</label>
             <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><CalendarClock className={iconClass} /></div>
-                <input type="number" name="frequency_in_days" id="frequency_in_days" value={formData.frequency_in_days || ''} onChange={handleChange} className={`${inputClass} pl-10`} min="1" />
+                <TextField type="number" name="frequency_in_days" id="frequency_in_days" value={formData.frequency_in_days || ''} onChange={handleChange} className="pl-10" min="1" />
             </div>
             {formErrors.frequency_in_days && <p className="text-xs text-red-500 mt-1">{formErrors.frequency_in_days}</p>}
           </div>
@@ -130,7 +130,7 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
             <label htmlFor="description" className={labelClass}>Description</label>
             <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className={`${inputClass} pl-10`}></textarea>
+                <TextAreaField name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className="pl-10" />
             </div>
           </div>
 

--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { RentalItemFormData, Equipment as EquipmentType } from '../../types';
 import { Trash2, PackagePlus } from 'lucide-react';
 import { formatCurrency } from '../../utils/formatting';
+import { TextField, SelectField } from '../ui/FormField';
 
 interface Props {
   items: RentalItemFormData[];
@@ -11,7 +12,6 @@ interface Props {
   handleItemChange: (index: number, field: keyof RentalItemFormData, value: string) => void;
   removeItem: (index: number) => void;
   addItem: () => void;
-  inputClass: string;
   labelClass: string;
 }
 
@@ -23,7 +23,6 @@ const RentalItemsSection: React.FC<Props> = ({
   handleItemChange,
   removeItem,
   addItem,
-  inputClass,
   labelClass,
 }) => (
   <fieldset>
@@ -45,11 +44,11 @@ const RentalItemsSection: React.FC<Props> = ({
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <div className="md:col-span-2">
               <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
-              <select
+              <SelectField
                 id={`item_equipment_${index}`}
                 value={item.equipment_id}
                 onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
-                className={`${inputClass} text-xs py-1.5`}
+                className="text-xs py-1.5"
                 disabled={loadingEquipment}
               >
                 <option value="">{loadingEquipment ? 'Loading...' : 'Select Equipment'}</option>
@@ -58,29 +57,29 @@ const RentalItemsSection: React.FC<Props> = ({
                     {eq.equipment_name} (SN: {eq.serial_number || 'N/A'}) - Rate: {formatCurrency(eq.rental_rate)}
                   </option>
                 ))}
-              </select>
+              </SelectField>
               {formErrors[`rental_items.${index}.equipment_id`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>}
             </div>
             <div>
               <label htmlFor={`item_quantity_${index}`} className={`${labelClass} text-xs`}>Quantity <span className="text-red-500">*</span></label>
-              <input
+              <TextField
                 type="number"
                 id={`item_quantity_${index}`}
                 value={item.quantity}
                 onChange={(e) => handleItemChange(index, 'quantity', e.target.value)}
-                className={`${inputClass} text-xs py-1.5`}
+                className="text-xs py-1.5"
                 min="1"
               />
                {formErrors[`rental_items.${index}.quantity`] && <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.quantity`]}</p>}
             </div>
             <div>
               <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
-              <input
+              <TextField
                 type="number"
                 id={`item_rate_${index}`}
                 value={item.unit_rental_rate}
                 onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
-                className={`${inputClass} text-xs py-1.5`}
+                className="text-xs py-1.5"
                 step="0.01"
                 min="0"
                 placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -30,6 +30,7 @@ import {
 import Modal from '../ui/Modal';
 import RentalItemsSection from './RentalItemsSection';
 import { formatCurrency } from '../../utils/formatting'; // Import formatCurrency
+import { TextField, SelectField, TextAreaField } from '../ui/FormField';
 
 const RENTAL_STATUSES_FORM = ["Draft", "Pending Confirmation", "Confirmed/Booked", "Active/Rented Out", "Returned/Completed", "Overdue", "Cancelled"];
 
@@ -476,7 +477,6 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
     }
   };
 
-  const inputClass = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm disabled:bg-light-gray-100";
   const labelClass = "block text-sm font-medium text-dark-text";
   const iconClass = "h-5 w-5 text-gray-400";
 
@@ -507,23 +507,23 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   {loadingCustomers ? <Loader2 className={`${iconClass} animate-spin`} /> : <User className={iconClass} />}
                 </div>
-                <select name="customer_id" id="customer_id" value={formData.customer_id} onChange={handleChange} className={`${inputClass} pl-10`} required disabled={loadingCustomers}>
+                <SelectField name="customer_id" id="customer_id" value={formData.customer_id} onChange={handleChange} className="pl-10" required disabled={loadingCustomers}>
                   <option value="">{loadingCustomers ? "Loading..." : "Select Customer"}</option>
                   {customers.map((c: CustomerType) => <option key={c.customer_id} value={c.customer_id}>{c.full_name}</option>)}
-                </select>
+                </SelectField>
               </div>
               {formErrors.customer_id && <p className="text-xs text-red-500 mt-1">{formErrors.customer_id}</p>}
             </div>
 
             <div>
               <label htmlFor="rental_date" className={labelClass}>Rental Date <span className="text-red-500">*</span></label>
-              <input type="date" name="rental_date" id="rental_date" value={formData.rental_date} onChange={handleChange} className={inputClass} required />
+              <TextField type="date" name="rental_date" id="rental_date" value={formData.rental_date} onChange={handleChange} required />
               {formErrors.rental_date && <p className="text-xs text-red-500 mt-1">{formErrors.rental_date}</p>}
             </div>
 
             <div>
               <label htmlFor="expected_return_date" className={labelClass}>Expected Return Date <span className="text-red-500">*</span></label>
-              <input type="date" name="expected_return_date" id="expected_return_date" value={formData.expected_return_date || ''} onChange={handleChange} className={inputClass} required />
+              <TextField type="date" name="expected_return_date" id="expected_return_date" value={formData.expected_return_date || ''} onChange={handleChange} required />
               {formErrors.expected_return_date && <p className="text-xs text-red-500 mt-1">{formErrors.expected_return_date}</p>}
             </div>
              <div>
@@ -538,9 +538,9 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               <label htmlFor="status" className={labelClass}>Status <span className="text-red-500">*</span></label>
                <div className="mt-1 relative rounded-md shadow-sm">
                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><ChevronDown className={iconClass} /></div>
-                <select name="status" id="status" value={formData.status || ''} onChange={handleChange} className={`${inputClass} pl-10`} required>
+                <SelectField name="status" id="status" value={formData.status || ''} onChange={handleChange} className="pl-10" required>
                     {RENTAL_STATUSES_FORM.map(s => <option key={s} value={s}>{s}</option>)}
-                </select>
+                </SelectField>
               </div>
           {formErrors.status && <p className="text-xs text-red-500 mt-1">{formErrors.status}</p>}
         </div>
@@ -554,32 +554,32 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         </div>
         <div className="md:col-span-2">
           <label htmlFor="shipping_address" className={labelClass}>Shipping Address</label>
-          <textarea id="shipping_address" name="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
+          <TextAreaField id="shipping_address" name="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} />
         </div>
         <div>
           <label htmlFor="shipping_area" className={labelClass}>Shipping Area</label>
           {shippingIsAreaSelect ? (
-            <select id="shipping_area" name="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass}>
+            <SelectField id="shipping_area" name="shipping_area" value={formData.shipping_area || ''} onChange={handleChange}>
               <option value="">Select Area</option>
               {shippingAreaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-            </select>
+            </SelectField>
           ) : (
-            <input type="text" id="shipping_area" name="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={shippingAreaOptions.length > 0 && !shippingIsAreaSelect} />
+            <TextField type="text" id="shipping_area" name="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} readOnly={shippingAreaOptions.length > 0 && !shippingIsAreaSelect} />
           )}
           {formErrors.shipping_area && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_area}</p>}
         </div>
         <div>
           <label htmlFor="shipping_city" className={labelClass}>Shipping City</label>
-          <input type="text" id="shipping_city" name="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} className={inputClass} readOnly />
+          <TextField type="text" id="shipping_city" name="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} readOnly />
         </div>
         <div>
           <label htmlFor="shipping_state" className={labelClass}>Shipping State</label>
-          <input type="text" id="shipping_state" name="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
+          <TextField type="text" id="shipping_state" name="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} readOnly />
         </div>
         <div>
           <label htmlFor="shipping_pincode" className={labelClass}>Shipping Pincode</label>
           <div className="relative">
-            <input type="text" id="shipping_pincode" name="shipping_pincode" value={formData.shipping_pincode || ''} onChange={handleChange} className={inputClass} maxLength={6} />
+            <TextField type="text" id="shipping_pincode" name="shipping_pincode" value={formData.shipping_pincode || ''} onChange={handleChange} maxLength={6} />
             {shippingPincodeDetailsLoading && (
               <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
                 <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
@@ -591,32 +591,32 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         </div>
         <div className="md:col-span-2">
           <label htmlFor="billing_address" className={labelClass}>Billing Address</label>
-          <textarea id="billing_address" name="billing_address" value={formData.billing_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
+          <TextAreaField id="billing_address" name="billing_address" value={formData.billing_address || ''} onChange={handleChange} rows={2} />
         </div>
         <div>
           <label htmlFor="billing_area" className={labelClass}>Billing Area</label>
           {billingIsAreaSelect ? (
-            <select id="billing_area" name="billing_area" value={formData.billing_area || ''} onChange={handleChange} className={inputClass}>
+            <SelectField id="billing_area" name="billing_area" value={formData.billing_area || ''} onChange={handleChange}>
               <option value="">Select Area</option>
               {billingAreaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-            </select>
+            </SelectField>
           ) : (
-            <input type="text" id="billing_area" name="billing_area" value={formData.billing_area || ''} onChange={handleChange} className={inputClass} readOnly={billingAreaOptions.length > 0 && !billingIsAreaSelect} />
+            <TextField type="text" id="billing_area" name="billing_area" value={formData.billing_area || ''} onChange={handleChange} readOnly={billingAreaOptions.length > 0 && !billingIsAreaSelect} />
           )}
           {formErrors.billing_area && <p className="text-xs text-red-500 mt-1">{formErrors.billing_area}</p>}
         </div>
         <div>
           <label htmlFor="billing_city" className={labelClass}>Billing City</label>
-          <input type="text" id="billing_city" name="billing_city" value={formData.billing_city || ''} onChange={handleChange} className={inputClass} readOnly />
+          <TextField type="text" id="billing_city" name="billing_city" value={formData.billing_city || ''} onChange={handleChange} readOnly />
         </div>
         <div>
           <label htmlFor="billing_state" className={labelClass}>Billing State</label>
-          <input type="text" id="billing_state" name="billing_state" value={formData.billing_state || ''} onChange={handleChange} className={inputClass} readOnly />
+          <TextField type="text" id="billing_state" name="billing_state" value={formData.billing_state || ''} onChange={handleChange} readOnly />
         </div>
         <div>
           <label htmlFor="billing_pincode" className={labelClass}>Billing Pincode</label>
           <div className="relative">
-            <input type="text" id="billing_pincode" name="billing_pincode" value={formData.billing_pincode || ''} onChange={handleChange} className={inputClass} maxLength={6} />
+            <TextField type="text" id="billing_pincode" name="billing_pincode" value={formData.billing_pincode || ''} onChange={handleChange} maxLength={6} />
             {billingPincodeDetailsLoading && (
               <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
                 <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
@@ -628,11 +628,11 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         </div>
         <div>
           <label htmlFor="mobile_number" className={labelClass}>Mobile Number</label>
-          <input type="text" id="mobile_number" name="mobile_number" value={formData.mobile_number || ''} onChange={handleChange} className={inputClass} />
+          <TextField type="text" id="mobile_number" name="mobile_number" value={formData.mobile_number || ''} onChange={handleChange} />
         </div>
         <div>
           <label htmlFor="email" className={labelClass}>Email</label>
-          <input type="email" id="email" name="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
+          <TextField type="email" id="email" name="email" value={formData.email || ''} onChange={handleChange} />
         </div>
       </fieldset>
 
@@ -644,7 +644,6 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             handleItemChange={handleItemChange}
             removeItem={removeItem}
             addItem={addItem}
-            inputClass={inputClass}
             labelClass={labelClass}
           />
 
@@ -656,17 +655,17 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                     {loadingPaymentPlans ? <Loader2 className={`${iconClass} animate-spin`} /> : <ListChecks className={iconClass} />}
                 </div>
-                <select name="payment_term" id="payment_term" value={formData.payment_term || ''} onChange={handleChange} className={`${inputClass} pl-10`} disabled={loadingPaymentPlans}>
+                <SelectField name="payment_term" id="payment_term" value={formData.payment_term || ''} onChange={handleChange} className="pl-10" disabled={loadingPaymentPlans}>
                   <option value="">{loadingPaymentPlans ? "Loading..." : "Select Payment Term"}</option>
                   {paymentPlans.map((pt: PaymentPlanType) => <option key={pt.plan_id} value={pt.plan_name}>{pt.plan_name}</option>)}
-                </select>
+                </SelectField>
               </div>
             </div>
             <div>
               <label htmlFor="deposit" className={labelClass}>Deposit Amount (₹)</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><IndianRupee className={iconClass} /></div>
-                <input type="number" name="deposit" id="deposit" value={formData.deposit || ''} onChange={handleChange} className={`${inputClass} pl-10`} step="0.01" min="0"/>
+                <TextField type="number" name="deposit" id="deposit" value={formData.deposit || ''} onChange={handleChange} className="pl-10" step="0.01" min="0"/>
               </div>
               {formErrors.deposit && <p className="text-xs text-red-500 mt-1">{formErrors.deposit}</p>}
             </div>
@@ -682,7 +681,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               <label htmlFor="notes" className={labelClass}>Notes</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="notes" id="notes" value={formData.notes || ''} onChange={handleChange} rows={3} className={`${inputClass} pl-10`}></textarea>
+                <TextAreaField name="notes" id="notes" value={formData.notes || ''} onChange={handleChange} rows={3} className="pl-10" />
               </div>
             </div>
           </fieldset>

--- a/src/components/ui/FormField.tsx
+++ b/src/components/ui/FormField.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const baseClasses = "mt-1 block w-full px-3 py-2 bg-white border border-light-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm disabled:bg-light-gray-100";
+
+export const TextField = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function TextField({ className = '', ...props }, ref) {
+  return <input ref={ref} className={`${baseClasses} ${className}`.trim()} {...props} />;
+});
+
+export const SelectField = React.forwardRef<HTMLSelectElement, React.SelectHTMLAttributes<HTMLSelectElement>>(function SelectField({ className = '', children, ...props }, ref) {
+  return <select ref={ref} className={`${baseClasses} ${className}`.trim()} {...props}>{children}</select>;
+});
+
+export const TextAreaField = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(function TextAreaField({ className = '', ...props }, ref) {
+  return <textarea ref={ref} className={`${baseClasses} ${className}`.trim()} {...props} />;
+});
+
+export default { TextField, SelectField, TextAreaField };


### PR DESCRIPTION
## Summary
- add generic `FormField` utilities for text/select/textarea inputs
- refactor forms to use these new components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68403259791c8321ad31f8abcc754c5f