### PR TITLE
Refactor dashboard tabs

### DIFF
--- a/src/components/dashboard/DeleteMaintenanceModal.tsx
+++ b/src/components/dashboard/DeleteMaintenanceModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ConfirmationModal from '../ui/ConfirmationModal';
+import { MaintenanceRecord } from '../../types';
+
+interface DeleteMaintenanceModalProps {
+  isOpen: boolean;
+  record: MaintenanceRecord | null;
+  isLoading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const DeleteMaintenanceModal: React.FC<DeleteMaintenanceModalProps> = ({
+  isOpen,
+  record,
+  isLoading,
+  onConfirm,
+  onCancel,
+}) => (
+  <ConfirmationModal
+    isOpen={isOpen}
+    title="Delete Maintenance Record"
+    message={`Are you sure you want to delete the maintenance record for "${record?.equipment_name || `ID: ${record?.equipment_id}`}" on ${record?.maintenance_date}? This action cannot be undone.`}
+    onConfirm={onConfirm}
+    onCancel={onCancel}
+    isLoading={isLoading}
+    confirmText="Delete"
+  />
+);
+
+export default DeleteMaintenanceModal;

--- a/src/components/dashboard/EquipmentFilterPanel.tsx
+++ b/src/components/dashboard/EquipmentFilterPanel.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import SearchBox from '../ui/SearchBox';
+import { EquipmentCategory } from '../../types';
+
+interface EquipmentFilters {
+  status: string | null;
+  category_id: number | string | null;
+}
+
+interface EquipmentFilterPanelProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  filters: EquipmentFilters;
+  onFiltersChange: (update: Partial<EquipmentFilters>) => void;
+  categories: EquipmentCategory[];
+  loadingCategories: boolean;
+  categoriesError: string | null;
+}
+
+const equipmentStatusesForFilter = ['Available', 'Rented', 'Maintenance', 'Decommissioned', 'Lost'];
+
+const EquipmentFilterPanel: React.FC<EquipmentFilterPanelProps> = ({
+  searchQuery,
+  onSearchChange,
+  filters,
+  onFiltersChange,
+  categories,
+  loadingCategories,
+  categoriesError,
+}) => (
+  <div className="mb-6 p-4 bg-white rounded-lg shadow">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+      <div className="md:col-span-1">
+        <label htmlFor="equipmentSearch" className="block text-sm font-medium text-dark-text mb-1">Search Equipment</label>
+        <SearchBox
+          value={searchQuery}
+          onChange={onSearchChange}
+          placeholder="Search by name, serial..."
+        />
+      </div>
+      <div>
+        <label htmlFor="equipmentStatusFilter" className="block text-sm font-medium text-dark-text mb-1">Status</label>
+        <select
+          id="equipmentStatusFilter"
+          name="status"
+          value={filters.status || 'all'}
+          onChange={(e) => onFiltersChange({ status: e.target.value === 'all' ? null : e.target.value })}
+          className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
+        >
+          <option value="all">All Statuses</option>
+          {equipmentStatusesForFilter.map(status => (
+            <option key={status} value={status}>{status}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="equipmentCategoryFilter" className="block text-sm font-medium text-dark-text mb-1">Category</label>
+        <select
+          id="equipmentCategoryFilter"
+          name="category_id"
+          value={filters.category_id || 'all'}
+          onChange={(e) => onFiltersChange({ category_id: e.target.value === 'all' ? null : e.target.value })}
+          disabled={loadingCategories || !!categoriesError}
+          className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
+        >
+          <option value="all">{loadingCategories ? 'Loading...' : (categoriesError ? 'Error' : 'All Categories')}</option>
+          {!loadingCategories && !categoriesError && categories.map(cat => (
+            <option key={cat.category_id} value={String(cat.category_id)}>{cat.category_name}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  </div>
+);
+
+export default EquipmentFilterPanel;

--- a/src/components/dashboard/EquipmentTab.tsx
+++ b/src/components/dashboard/EquipmentTab.tsx
@@ -5,7 +5,7 @@ import { getEquipmentItem } from '../../services/api'; // Import for fetching si
 import EquipmentList from '../EquipmentList';
 import EquipmentForm from '../EquipmentForm';
 import EquipmentDetail from '../EquipmentDetail';
-import SearchBox from '../ui/SearchBox';
+import EquipmentFilterPanel from './EquipmentFilterPanel';
 import { PlusCircle } from 'lucide-react';
 import { Equipment } from '../../types';
 import Spinner from '../ui/Spinner'; // For loading state
@@ -16,7 +16,6 @@ interface EquipmentTabProps {
   clearInitialEquipmentIdToView: () => void; // To clear the ID after use
 }
 
-const equipmentStatusesForFilter = ['Available', 'Rented', 'Maintenance', 'Decommissioned', 'Lost'];
 
 const EquipmentTab: React.FC<EquipmentTabProps> = ({
   onViewMaintenanceForEquipment,
@@ -127,50 +126,16 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
   }
 
   return (
-    <>
-      <div className="mb-6 p-4 bg-white rounded-lg shadow">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-          <div className="md:col-span-1">
-            <label htmlFor="equipmentSearch" className="block text-sm font-medium text-dark-text mb-1">Search Equipment</label>
-            <SearchBox
-              value={equipmentSearchQuery}
-              onChange={setEquipmentSearchQuery}
-              placeholder="Search by name, serial..."
-            />
-          </div>
-          <div>
-            <label htmlFor="equipmentStatusFilter" className="block text-sm font-medium text-dark-text mb-1">Status</label>
-            <select
-              id="equipmentStatusFilter"
-              name="status"
-              value={equipmentFilters.status || 'all'}
-              onChange={(e) => setEquipmentFilters({ ...equipmentFilters, status: e.target.value === 'all' ? null : e.target.value })}
-              className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
-            >
-              <option value="all">All Statuses</option>
-              {equipmentStatusesForFilter.map(status => (
-                <option key={status} value={status}>{status}</option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label htmlFor="equipmentCategoryFilter" className="block text-sm font-medium text-dark-text mb-1">Category</label>
-            <select
-              id="equipmentCategoryFilter"
-              name="category_id"
-              value={equipmentFilters.category_id || 'all'}
-              onChange={(e) => setEquipmentFilters({ ...equipmentFilters, category_id: e.target.value === 'all' ? null : e.target.value })}
-              disabled={eqCategoriesLoadingForFilter || !!eqCategoriesFilterError}
-              className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
-            >
-              <option value="all">{eqCategoriesLoadingForFilter ? "Loading..." : (eqCategoriesFilterError ? "Error" : "All Categories")}</option>
-              {!eqCategoriesLoadingForFilter && !eqCategoriesFilterError && allEquipmentCategories.map(cat => (
-                <option key={cat.category_id} value={String(cat.category_id)}>{cat.category_name}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </div>
+      <>
+        <EquipmentFilterPanel
+          searchQuery={equipmentSearchQuery}
+          onSearchChange={setEquipmentSearchQuery}
+          filters={equipmentFilters}
+          onFiltersChange={setEquipmentFilters}
+          categories={allEquipmentCategories}
+          loadingCategories={eqCategoriesLoadingForFilter}
+          categoriesError={eqCategoriesFilterError}
+        />
 
       <div className="mb-6 flex justify-end">
         <button onClick={handleOpenEquipmentFormForCreate} className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue hover:bg-brand-blue/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue transition-colors">

--- a/src/components/dashboard/MaintenanceFilterBar.tsx
+++ b/src/components/dashboard/MaintenanceFilterBar.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import SearchBox from '../ui/SearchBox';
+import { Equipment } from '../../types';
+import { MaintenanceRecordFilters } from '../../context/MaintenanceRecordContext';
+
+interface MaintenanceFilterBarProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  filters: MaintenanceRecordFilters;
+  onFiltersChange: (update: Partial<MaintenanceRecordFilters>) => void;
+  equipmentList: Equipment[];
+  loadingEquipmentList: boolean;
+}
+
+const maintenanceTypesForFilter = ['Routine', 'Repair', 'Inspection', 'Upgrade', 'Calibration', 'Emergency'];
+
+const MaintenanceFilterBar: React.FC<MaintenanceFilterBarProps> = ({
+  searchQuery,
+  onSearchChange,
+  filters,
+  onFiltersChange,
+  equipmentList,
+  loadingEquipmentList,
+}) => (
+  <div className="mb-6 p-4 bg-white rounded-lg shadow">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+      <div className="md:col-span-1">
+        <label htmlFor="maintenanceSearch" className="block text-sm font-medium text-dark-text mb-1">Search Records</label>
+        <SearchBox
+          value={searchQuery}
+          onChange={onSearchChange}
+          placeholder="Search by technician, notes..."
+        />
+      </div>
+      <div>
+        <label htmlFor="maintenanceTypeFilter" className="block text-sm font-medium text-dark-text mb-1">Maintenance Type</label>
+        <select
+          id="maintenanceTypeFilter"
+          name="maintenance_type"
+          value={filters.maintenance_type || 'all'}
+          onChange={(e) => onFiltersChange({ maintenance_type: e.target.value === 'all' ? null : e.target.value })}
+          className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
+        >
+          <option value="all">All Types</option>
+          {maintenanceTypesForFilter.map(type => (
+            <option key={type} value={type}>{type}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label htmlFor="maintenanceEquipmentFilter" className="block text-sm font-medium text-dark-text mb-1">Equipment</label>
+        <select
+          id="maintenanceEquipmentFilter"
+          name="equipment_id"
+          value={filters.equipment_id || 'all'}
+          onChange={(e) => onFiltersChange({ equipment_id: e.target.value === 'all' ? null : e.target.value })}
+          disabled={loadingEquipmentList}
+          className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
+        >
+          <option value="all">{loadingEquipmentList ? 'Loading Equipment...' : 'All Equipment'}</option>
+          {!loadingEquipmentList && equipmentList.map(eq => (
+            <option key={eq.equipment_id} value={String(eq.equipment_id)}>{eq.equipment_name} ({eq.serial_number || 'N/A'})</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  </div>
+);
+
+export default MaintenanceFilterBar;

--- a/src/components/dashboard/MaintenanceTab.tsx
+++ b/src/components/dashboard/MaintenanceTab.tsx
@@ -3,8 +3,8 @@ import { useMaintenanceRecords } from '../../context/MaintenanceRecordContext';
 import { useCrud } from '../../context/CrudContext';
 import MaintenanceRecordList from '../MaintenanceRecordList';
 import MaintenanceRecordForm from '../MaintenanceRecordForm';
-import SearchBox from '../ui/SearchBox';
-import ConfirmationModal from '../ui/ConfirmationModal';
+import MaintenanceFilterBar from './MaintenanceFilterBar';
+import DeleteMaintenanceModal from './DeleteMaintenanceModal';
 import { PlusCircle, ListChecks } from 'lucide-react';
 import { MaintenanceRecord, MaintenanceRecordFormData } from '../../types';
 
@@ -13,7 +13,6 @@ interface MaintenanceTabProps {
   navigateToEquipmentDetail: (equipmentId: number) => void;
 }
 
-const maintenanceTypesForFilter = ['Routine', 'Repair', 'Inspection', 'Upgrade', 'Calibration', 'Emergency'];
 
 const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
   initialEquipmentIdFilter,
@@ -147,50 +146,15 @@ const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
       </div>
 
       {activeMaintenanceSubTab === 'list' && !isMaintenanceFormOpen && (
-        <>
-          <div className="mb-6 p-4 bg-white rounded-lg shadow">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-              <div className="md:col-span-1">
-                <label htmlFor="maintenanceSearch" className="block text-sm font-medium text-dark-text mb-1">Search Records</label>
-                <SearchBox
-                  value={maintenanceSearchQuery}
-                  onChange={setMaintenanceSearchQuery}
-                  placeholder="Search by technician, notes..."
-                />
-              </div>
-              <div>
-                <label htmlFor="maintenanceTypeFilter" className="block text-sm font-medium text-dark-text mb-1">Maintenance Type</label>
-                <select
-                  id="maintenanceTypeFilter"
-                  name="maintenance_type"
-                  value={maintenanceFilters.maintenance_type || 'all'}
-                  onChange={(e) => setMaintenanceFilters({ ...maintenanceFilters, maintenance_type: e.target.value === 'all' ? null : e.target.value })}
-                  className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
-                >
-                  <option value="all">All Types</option>
-                  {maintenanceTypesForFilter.map(type => (
-                    <option key={type} value={type}>{type}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label htmlFor="maintenanceEquipmentFilter" className="block text-sm font-medium text-dark-text mb-1">Equipment</label>
-                <select
-                  id="maintenanceEquipmentFilter"
-                  name="equipment_id"
-                  value={maintenanceFilters.equipment_id || 'all'}
-                  onChange={(e) => setMaintenanceFilters({ ...maintenanceFilters, equipment_id: e.target.value === 'all' ? null : e.target.value })}
-                  disabled={loadingEquipmentList}
-                  className="block w-full pl-3 pr-10 py-2 text-base border-light-gray-300 focus:outline-none focus:ring-brand-blue focus:border-brand-blue sm:text-sm rounded-md shadow-sm"
-                >
-                  <option value="all">{loadingEquipmentList ? "Loading Equipment..." : "All Equipment"}</option>
-                  {!loadingEquipmentList && equipmentListForFilter.map(eq => (
-                    <option key={eq.equipment_id} value={String(eq.equipment_id)}>{eq.equipment_name} ({eq.serial_number || 'N/A'})</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-          </div>
+          <>
+            <MaintenanceFilterBar
+              searchQuery={maintenanceSearchQuery}
+              onSearchChange={setMaintenanceSearchQuery}
+              filters={maintenanceFilters}
+              onFiltersChange={setMaintenanceFilters}
+              equipmentList={equipmentListForFilter}
+              loadingEquipmentList={loadingEquipmentList}
+            />
 
           <div className="mb-6 flex justify-end">
             <button onClick={handleOpenMaintenanceFormForCreate} className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue hover:bg-brand-blue/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue transition-colors">
@@ -221,14 +185,12 @@ const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
         />
       )}
 
-       <ConfirmationModal
+       <DeleteMaintenanceModal
         isOpen={isConfirmDeleteModalOpen}
-        title="Delete Maintenance Record"
-        message={`Are you sure you want to delete the maintenance record for "${recordToDelete?.equipment_name || `ID: ${recordToDelete?.equipment_id}`}" on ${recordToDelete?.maintenance_date}? This action cannot be undone.`}
+        record={recordToDelete}
         onConfirm={confirmDeleteRecord}
         onCancel={() => setIsConfirmDeleteModalOpen(false)}
         isLoading={crudLoading}
-        confirmText="Delete"
       />
     </>
   );


### PR DESCRIPTION
## Summary
- isolate filtering UI for equipment listings
- modularize maintenance filters and delete modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840325ba6e08321b2458cb33fe6820e