### PR TITLE
Replace modal forms with inline/pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -1952,6 +1953,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3298,6 +3308,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3436,6 +3484,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import { PaymentPlanProvider } from './context/PaymentPlanContext';
 import { MaintenanceRecordProvider } from './context/MaintenanceRecordContext';
 import { RentalTransactionProvider } from './context/RentalTransactionContext'; // Import new provider
 import Dashboard from './components/Dashboard';
+import { Routes, Route } from 'react-router-dom';
+import CustomerFormPage from './components/pages/CustomerFormPage';
+import EquipmentFormPage from './components/pages/EquipmentFormPage';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -18,8 +21,14 @@ function App() {
           <EquipmentCategoryProvider>
             <PaymentPlanProvider>
               <MaintenanceRecordProvider>
-                <RentalTransactionProvider> {/* Add new provider */}
-                  <Dashboard sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+                <RentalTransactionProvider>
+                  <Routes>
+                    <Route path="/" element={<Dashboard sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />} />
+                    <Route path="/customers/new" element={<CustomerFormPage />} />
+                    <Route path="/customers/:id/edit" element={<CustomerFormPage />} />
+                    <Route path="/equipment/new" element={<EquipmentFormPage />} />
+                    <Route path="/equipment/:id/edit" element={<EquipmentFormPage />} />
+                  </Routes>
                 </RentalTransactionProvider>
               </MaintenanceRecordProvider>
             </PaymentPlanProvider>

--- a/src/components/CustomerForm.tsx
+++ b/src/components/CustomerForm.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Customer, CustomerFormData } from '../types';
 import { useCrud } from '../context/CrudContext';
 import { Save, X, Loader2 } from 'lucide-react';
-import Modal from './ui/Modal';
 import CustomerPersonalInfoSection from './customers/CustomerPersonalInfoSection';
 import CustomerShippingInfoSection from './customers/CustomerShippingInfoSection';
 import usePincodeLookup from '../utils/usePincodeLookup';
@@ -161,11 +160,15 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
   const labelClass = "block text-sm font-medium text-dark-text";
 
   return (
-    <Modal
-      title={customer ? 'Edit Customer' : 'Add New Customer'}
-      widthClasses="max-w-2xl"
-      onClose={onCancel}
-    >
+    <div className="bg-white rounded-lg shadow max-w-2xl mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue">
+          {customer ? 'Edit Customer' : 'Add New Customer'}
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4" role="alert">
@@ -217,7 +220,7 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/components/EquipmentForm.tsx
+++ b/src/components/EquipmentForm.tsx
@@ -7,7 +7,6 @@ import EquipmentBasicInfo from './equipment/EquipmentBasicInfo';
 import EquipmentIdentification from './equipment/EquipmentIdentification';
 import EquipmentFinancial from './equipment/EquipmentFinancial';
 import EquipmentDatesLocation from './equipment/EquipmentDatesLocation';
-import Modal from './ui/Modal';
 
 interface EquipmentFormProps {
   equipment?: Equipment | null;
@@ -173,16 +172,16 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
   const iconClass = "h-5 w-5 text-gray-400 mr-2";
 
   return (
-    <Modal
-      title={(
-        <span className="flex items-center">
+    <div className="bg-white rounded-lg shadow max-w-3xl mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <Package className="h-6 w-6 mr-2 text-brand-blue" />
           {isEditing ? 'Edit Equipment' : 'Add New Equipment'}
-        </span>
-      )}
-      widthClasses="max-w-3xl"
-      onClose={onCancel}
-    >
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded" role="alert">
@@ -262,7 +261,7 @@ const EquipmentForm: React.FC<EquipmentFormProps> = ({ equipment, onSave, onCanc
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/components/MaintenanceRecordForm.tsx
+++ b/src/components/MaintenanceRecordForm.tsx
@@ -6,7 +6,6 @@ import { MaintenanceRecordFormData } from '../types';
 import { useMaintenanceRecords } from '../context/MaintenanceRecordContext'; // To get equipment list
 import { useCrud } from '../context/CrudContext'; // To get loading state from CRUD operations
 import { Save, X, Loader2, Wrench, ChevronDown } from 'lucide-react';
-import Modal from './ui/Modal';
 import MaintenanceRecordInfo from './maintenance/MaintenanceRecordInfo';
 import MaintenanceRecordExtra from './maintenance/MaintenanceRecordExtra';
 
@@ -164,16 +163,16 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
   const iconClass = "h-5 w-5 text-gray-400";
 
   return (
-    <Modal
-      title={(
-        <span className="flex items-center">
+    <div className="bg-white rounded-lg shadow max-w-2xl mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <Wrench className="h-6 w-6 mr-2 text-brand-blue" />
           {isEditMode ? 'Edit Maintenance Record' : 'Add New Maintenance Record'}
-        </span>
-      )}
-      widthClasses="max-w-2xl"
-      onClose={onCancel}
-    >
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded" role="alert">
@@ -267,7 +266,7 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/components/dashboard/CustomerTab.tsx
+++ b/src/components/dashboard/CustomerTab.tsx
@@ -2,24 +2,21 @@ import React, { useState } from 'react';
 import { useCustomers } from '../../context/CustomerContext';
 import CustomerList from '../CustomerList';
 import CustomerDetail from '../CustomerDetail';
-import CustomerForm from '../CustomerForm';
+import { useNavigate } from 'react-router-dom';
 import SearchBox from '../ui/SearchBox';
 import { PlusCircle } from 'lucide-react';
 import { Customer } from '../../types';
 
 // No props needed from Dashboard for its internal UI state management
 const CustomerTab: React.FC = () => {
-  const { searchQuery, setSearchQuery, refreshData } = useCustomers();
+  const { searchQuery, setSearchQuery } = useCustomers();
 
   // State managed within CustomerTab
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
-  const [isCustomerFormOpen, setIsCustomerFormOpen] = useState(false);
-  const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
+  const navigate = useNavigate();
 
   const handleSelectCustomerForDetail = (customer: Customer) => {
     setSelectedCustomer(customer);
-    setIsCustomerFormOpen(false); // Close form if open
-    setEditingCustomer(null);
   };
 
   const handleCloseCustomerDetail = () => {
@@ -27,26 +24,15 @@ const CustomerTab: React.FC = () => {
   };
 
   const handleOpenCustomerFormForCreate = () => {
-    setEditingCustomer(null);
-    setSelectedCustomer(null); // Close detail if open
-    setIsCustomerFormOpen(true);
+    setSelectedCustomer(null);
+    navigate('/customers/new');
   };
 
   const handleOpenCustomerFormForEdit = (customer: Customer) => {
-    setEditingCustomer(customer);
-    setSelectedCustomer(null); // Close detail view
-    setIsCustomerFormOpen(true);
+    setSelectedCustomer(null);
+    navigate(`/customers/${customer.customer_id}/edit`, { state: { customer } });
   };
 
-  const handleCloseCustomerForm = () => {
-    setIsCustomerFormOpen(false);
-    setEditingCustomer(null);
-  };
-
-  const handleSaveCustomerForm = () => {
-    handleCloseCustomerForm();
-    refreshData(); // Refresh customer list from context
-  };
 
   return (
     <>
@@ -66,18 +52,11 @@ const CustomerTab: React.FC = () => {
         onEditCustomer={handleOpenCustomerFormForEdit}
       />
 
-      {selectedCustomer && !isCustomerFormOpen && ( // Show detail only if form is not open
+      {selectedCustomer && (
         <CustomerDetail
           customer={selectedCustomer}
           onClose={handleCloseCustomerDetail}
           onEdit={() => handleOpenCustomerFormForEdit(selectedCustomer)}
-        />
-      )}
-      {isCustomerFormOpen && (
-        <CustomerForm
-          customer={editingCustomer}
-          onSave={handleSaveCustomerForm}
-          onCancel={handleCloseCustomerForm}
         />
       )}
     </>

--- a/src/components/dashboard/EquipmentTab.tsx
+++ b/src/components/dashboard/EquipmentTab.tsx
@@ -3,7 +3,7 @@ import { useEquipment } from '../../context/EquipmentContext';
 import { useEquipmentCategories } from '../../context/EquipmentCategoryContext';
 import { getEquipmentItem } from '../../services/api/equipment'; // Import for fetching single equipment
 import EquipmentList from '../EquipmentList';
-import EquipmentForm from '../EquipmentForm';
+import { useNavigate } from 'react-router-dom';
 import EquipmentDetail from '../EquipmentDetail';
 import EquipmentFilterPanel from './EquipmentFilterPanel';
 import { PlusCircle } from 'lucide-react';
@@ -26,7 +26,6 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
     equipmentList, // Use the list from context
     searchQuery: equipmentSearchQuery,
     setSearchQuery: setEquipmentSearchQuery,
-    refreshEquipmentData,
     filters: equipmentFilters,
     setFilters: setEquipmentFilters,
     loading: equipmentListLoading, // Loading state for the list
@@ -41,8 +40,7 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
   } = useEquipmentCategories();
 
   const [selectedEquipment, setSelectedEquipment] = useState<Equipment | null>(null);
-  const [isEquipmentFormOpen, setIsEquipmentFormOpen] = useState(false);
-  const [editingEquipment, setEditingEquipment] = useState<Equipment | null>(null);
+  const navigate = useNavigate();
   const [detailLoading, setDetailLoading] = useState(false); // Loading state for single equipment detail
 
   useEffect(() => {
@@ -86,8 +84,6 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
 
   const handleSelectEquipmentForDetail = (equipment: Equipment) => {
     setSelectedEquipment(equipment);
-    setIsEquipmentFormOpen(false);
-    setEditingEquipment(null);
   };
 
   const handleCloseEquipmentDetail = () => {
@@ -95,25 +91,13 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
   };
 
   const handleOpenEquipmentFormForCreate = () => {
-    setEditingEquipment(null);
     setSelectedEquipment(null);
-    setIsEquipmentFormOpen(true);
+    navigate('/equipment/new');
   };
 
   const handleOpenEquipmentFormForEdit = (item: Equipment) => {
-    setEditingEquipment(item);
     setSelectedEquipment(null);
-    setIsEquipmentFormOpen(true);
-  };
-
-  const handleCloseEquipmentForm = () => {
-    setIsEquipmentFormOpen(false);
-    setEditingEquipment(null);
-  };
-
-  const handleSaveEquipmentForm = () => {
-    handleCloseEquipmentForm();
-    refreshEquipmentData();
+    navigate(`/equipment/${item.equipment_id}/edit`, { state: { equipment: item } });
   };
 
   if (detailLoading) {
@@ -148,14 +132,7 @@ const EquipmentTab: React.FC<EquipmentTabProps> = ({
         onViewDetail={handleSelectEquipmentForDetail}
       />
 
-      {isEquipmentFormOpen && (
-        <EquipmentForm
-          equipment={editingEquipment}
-          onSave={handleSaveEquipmentForm}
-          onCancel={handleCloseEquipmentForm}
-        />
-      )}
-      {selectedEquipment && !isEquipmentFormOpen && (
+      {selectedEquipment && (
         <EquipmentDetail
           equipment={selectedEquipment}
           categoryName={getCategoryNameById(selectedEquipment.category_id)}

--- a/src/components/masters/EquipmentCategoryForm.tsx
+++ b/src/components/masters/EquipmentCategoryForm.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { EquipmentCategory, EquipmentCategoryFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, Tag, Info } from 'lucide-react';
-import Modal from '../ui/Modal';
 
 interface EquipmentCategoryFormProps {
   category?: EquipmentCategory | null;
@@ -78,16 +77,16 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
 
 
   return (
-    <Modal
-      title={(
-        <span className="flex items-center">
+    <div className="bg-white rounded-lg shadow max-w-lg mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <Tag className="h-6 w-6 mr-2 text-brand-blue" />
           {category ? 'Edit Equipment Category' : 'Add New Equipment Category'}
-        </span>
-      )}
-      widthClasses="max-w-lg"
-      onClose={onCancel}
-    >
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded" role="alert">
@@ -136,7 +135,7 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/components/masters/PaymentPlanForm.tsx
+++ b/src/components/masters/PaymentPlanForm.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { PaymentPlan, PaymentPlanFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, ListChecks, Info, CalendarClock } from 'lucide-react';
-import Modal from '../ui/Modal';
 
 interface PaymentPlanFormProps {
   plan?: PaymentPlan | null;
@@ -90,16 +89,16 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
   const iconClass = "h-5 w-5 text-gray-400";
 
   return (
-    <Modal
-      title={(
-        <span className="flex items-center">
+    <div className="bg-white rounded-lg shadow max-w-lg mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <ListChecks className="h-6 w-6 mr-2 text-brand-blue" />
           {plan ? 'Edit Payment Plan' : 'Add New Payment Plan'}
-        </span>
-      )}
-      widthClasses="max-w-lg"
-      onClose={onCancel}
-    >
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded" role="alert">
@@ -158,7 +157,7 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/components/pages/CustomerFormPage.tsx
+++ b/src/components/pages/CustomerFormPage.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import CustomerForm from '../CustomerForm';
+import { Customer } from '../../types';
+import { getCustomer } from '../../services/api/customers';
+
+const CustomerFormPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
+  const location = useLocation() as { state?: { customer?: Customer } };
+  const [customer, setCustomer] = useState<Customer | null>(location.state?.customer || null);
+  const [loading, setLoading] = useState<boolean>(!!id && !customer);
+
+  useEffect(() => {
+    if (id && !customer) {
+      getCustomer(id).then(res => {
+        if (res.success && res.data) {
+          const data = Array.isArray(res.data) ? res.data[0] : res.data;
+          setCustomer(data as Customer);
+        }
+      }).finally(() => setLoading(false));
+    }
+  }, [id, customer]);
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <CustomerForm
+        customer={customer}
+        onSave={() => navigate('/')}
+        onCancel={() => navigate(-1)}
+      />
+    </div>
+  );
+};
+
+export default CustomerFormPage;

--- a/src/components/pages/EquipmentFormPage.tsx
+++ b/src/components/pages/EquipmentFormPage.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import EquipmentForm from '../EquipmentForm';
+import { Equipment } from '../../types';
+import { getEquipmentItem } from '../../services/api/equipment';
+
+const EquipmentFormPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
+  const location = useLocation() as { state?: { equipment?: Equipment } };
+  const [equipment, setEquipment] = useState<Equipment | null>(location.state?.equipment || null);
+  const [loading, setLoading] = useState<boolean>(!!id && !equipment);
+
+  useEffect(() => {
+    if (id && !equipment) {
+      getEquipmentItem(Number(id)).then(res => {
+        if (res.success && res.data) {
+          setEquipment(res.data as Equipment);
+        }
+      }).finally(() => setLoading(false));
+    }
+  }, [id, equipment]);
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <EquipmentForm
+        equipment={equipment}
+        onSave={() => navigate('/')}
+        onCancel={() => navigate(-1)}
+      />
+    </div>
+  );
+};
+
+export default EquipmentFormPage;

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -21,7 +21,6 @@ import {
   ListChecks,
   Info,
 } from 'lucide-react';
-import Modal from '../ui/Modal';
 import RentalItemsSection from './RentalItemsSection';
 import RentalCustomerSection from './RentalCustomerSection';
 import RentalStatusDates from './RentalStatusDates';
@@ -426,16 +425,16 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   const iconClass = "h-5 w-5 text-gray-400";
 
   return (
-    <Modal
-      title={(
-        <span className="flex items-center">
+    <div className="bg-white rounded-lg shadow max-w-3xl mx-auto">
+      <div className="flex justify-between items-center p-4 border-b border-light-gray-200">
+        <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <CalendarCheck2 className="h-6 w-6 mr-2 text-brand-blue" />
           {isEditing ? 'Edit Rental Transaction' : 'New Rental Transaction'}
-        </span>
-      )}
-      widthClasses="max-w-3xl max-h-[95vh]"
-      onClose={onCancel}
-    >
+        </h2>
+        <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
+          <X className="h-5 w-5 text-dark-text" />
+        </button>
+      </div>
         <form onSubmit={handleSubmit} className="p-4 sm:p-6 space-y-6 overflow-y-auto">
           {crudError && (
             <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded" role="alert">
@@ -579,7 +578,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             </button>
           </div>
         </form>
-    </Modal>
+    </div>
   );
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- remove modal wrappers from form components and add dedicated form pages
- configure routing with `react-router-dom`
- navigate to form pages from dashboard tabs
- update main entry with BrowserRouter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684044a8476c8321ad89c076f9bfdbb3