### PR TITLE
Add cross-navigation from customers to rentals

### DIFF
--- a/src/components/CustomerCard.tsx
+++ b/src/components/CustomerCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Customer } from '../types';
-import { User, Mail, Phone, MapPin, Calendar, Edit3, Trash2, Loader2 } from 'lucide-react';
+import { User, Mail, Phone, MapPin, Calendar, Edit3, Trash2, Loader2, CalendarCheck2 } from 'lucide-react';
 import { useCrud } from '../context/CrudContext';
 import ConfirmationModal from './ui/ConfirmationModal';
 import { useCustomers } from '../context/CustomerContext';
@@ -10,9 +10,10 @@ interface CustomerCardProps {
   customer: Customer;
   onClick?: (customer: Customer) => void;
   onEdit: (customer: Customer) => void;
+  onViewRentals?: (customerId: string) => void;
 }
 
-const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick, onEdit }) => {
+const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick, onEdit, onViewRentals }) => {
   const { deleteItem, loading: crudLoading } = useCrud();
   const { refreshData } = useCustomers();
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
@@ -77,6 +78,15 @@ const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick, onEdit }
               >
                 <Edit3 size={20} />
               </button>
+              {onViewRentals && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onViewRentals(String(customer.customer_id)); }}
+                  className="p-1 text-green-600 hover:text-green-700 rounded-full hover:bg-light-gray-100"
+                  aria-label="View Rentals"
+                >
+                  <CalendarCheck2 size={20} />
+                </button>
+              )}
               <button
                 onClick={handleDeleteClick}
                 disabled={crudLoading}

--- a/src/components/CustomerDetail.tsx
+++ b/src/components/CustomerDetail.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Customer } from '../types';
 import {
   User, Mail, Phone, MapPin, Calendar, X,
-  ArrowLeft, Edit3
+  ArrowLeft, Edit3, CalendarCheck2
 } from 'lucide-react';
 import { formatDate } from '../utils/formatting'; // Import formatDate utility
 import Modal from './ui/Modal';
@@ -11,6 +11,7 @@ interface CustomerDetailProps {
   customer: Customer | null;
   onClose: () => void;
   onEdit: (customer: Customer) => void;
+  onViewRentals?: (customerId: string) => void;
   /**
    * Render the detail inside a modal overlay. Defaults to true.
    * When false, the component renders inline for use on dedicated pages.
@@ -18,7 +19,7 @@ interface CustomerDetailProps {
   isModal?: boolean;
 }
 
-const CustomerDetail: React.FC<CustomerDetailProps> = ({ customer, onClose, onEdit, isModal = true }) => {
+const CustomerDetail: React.FC<CustomerDetailProps> = ({ customer, onClose, onEdit, onViewRentals, isModal = true }) => {
   if (!customer) {
     return null;
   }
@@ -34,6 +35,12 @@ const CustomerDetail: React.FC<CustomerDetailProps> = ({ customer, onClose, onEd
 
   const handleEditClick = () => {
     onEdit(customer);
+  };
+
+  const handleViewRentalsClick = () => {
+    if (onViewRentals) {
+      onViewRentals(String(customer.customer_id));
+    }
   };
 
   const content = (
@@ -56,7 +63,16 @@ const CustomerDetail: React.FC<CustomerDetailProps> = ({ customer, onClose, onEd
                 >
                     <Edit3 className="h-5 w-5" />
                 </button>
-                 <button
+                {onViewRentals && (
+                  <button
+                      onClick={handleViewRentalsClick}
+                      className="p-2 rounded-full hover:bg-light-gray-100 text-green-600"
+                      aria-label="View Rentals"
+                  >
+                      <CalendarCheck2 className="h-5 w-5" />
+                  </button>
+                )}
+                <button
                     onClick={onClose}
                     className="p-2 rounded-full hover:bg-light-gray-100"
                     aria-label="Close"

--- a/src/components/CustomerList.tsx
+++ b/src/components/CustomerList.tsx
@@ -10,11 +10,13 @@ import { Customer } from '../types';
 interface CustomerListProps {
   onSelectCustomer: (customer: Customer) => void;
   onEditCustomer: (customer: Customer) => void; // Add this prop
+  onViewRentals: (customerId: string) => void;
 }
 
-const CustomerList: React.FC<CustomerListProps> = ({ 
-  onSelectCustomer, 
-  onEditCustomer 
+const CustomerList: React.FC<CustomerListProps> = ({
+  onSelectCustomer,
+  onEditCustomer,
+  onViewRentals
 }) => {
   const { 
     customers, 
@@ -53,11 +55,12 @@ const CustomerList: React.FC<CustomerListProps> = ({
     <div className="space-y-6">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
         {customers.map(customer => (
-          <CustomerCard 
-            key={customer.customer_id} 
-            customer={customer} 
+          <CustomerCard
+            key={customer.customer_id}
+            customer={customer}
             onClick={onSelectCustomer}
             onEdit={onEditCustomer} // Pass down the onEditCustomer handler
+            onViewRentals={onViewRentals}
           />
         ))}
       </div>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -28,6 +28,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
   const [activeTab, setActiveTab] = useState('customers');
   const [initialMaintenanceEquipmentId, setInitialMaintenanceEquipmentId] = useState<string | null>(null);
   const [equipmentIdForDetailView, setEquipmentIdForDetailView] = useState<number | null>(null);
+  const [initialRentalCustomerId, setInitialRentalCustomerId] = useState<string | null>(null);
 
   const { refreshData: refreshCustomerData, loading: customersLoading } = useCustomers();
   const { refreshEquipmentData, loading: equipmentLoading } = useEquipment();
@@ -86,6 +87,11 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
     setEquipmentIdForDetailView(null);
   };
 
+  const handleViewRentalsForCustomer = (customerId: string) => {
+    setInitialRentalCustomerId(customerId);
+    setActiveTab('rentals');
+  };
+
   useEffect(() => {
     if (activeTab !== 'maintenance' && initialMaintenanceEquipmentId) {
       setInitialMaintenanceEquipmentId(null);
@@ -94,7 +100,10 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
       // Consider if this auto-clearing is always desired
       // setEquipmentIdForDetailView(null);
     }
-  }, [activeTab, initialMaintenanceEquipmentId, equipmentIdForDetailView]);
+    if (activeTab !== 'rentals' && initialRentalCustomerId) {
+      setInitialRentalCustomerId(null);
+    }
+  }, [activeTab, initialMaintenanceEquipmentId, equipmentIdForDetailView, initialRentalCustomerId]);
 
   return (
     <div className="min-h-screen bg-light-gray-50 flex">
@@ -145,7 +154,9 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
         </header>
 
         <div className="flex-grow">
-          {activeTab === 'customers' && <CustomerTab />}
+          {activeTab === 'customers' && (
+            <CustomerTab onViewRentalsForCustomer={handleViewRentalsForCustomer} />
+          )}
           {activeTab === 'equipment' && (
             <EquipmentTab
               onViewMaintenanceForEquipment={handleViewMaintenanceForEquipment}
@@ -153,7 +164,12 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
               clearInitialEquipmentIdToView={clearEquipmentIdForDetailView}
             />
           )}
-          {activeTab === 'rentals' && <RentalsTab />} {/* Render new RentalsTab */}
+          {activeTab === 'rentals' && (
+            <RentalsTab
+              key={initialRentalCustomerId}
+              initialCustomerIdFilter={initialRentalCustomerId}
+            />
+          )} {/* Render new RentalsTab */}
           {activeTab === 'masters' && <MastersTab />}
           {activeTab === 'maintenance' && (
             <MaintenanceTab

--- a/src/components/dashboard/CustomerTab.tsx
+++ b/src/components/dashboard/CustomerTab.tsx
@@ -6,8 +6,12 @@ import SearchBox from '../ui/SearchBox';
 import { PlusCircle } from 'lucide-react';
 import { Customer } from '../../types';
 
+interface CustomerTabProps {
+  onViewRentalsForCustomer: (customerId: string) => void;
+}
+
 // No props needed from Dashboard for its internal UI state management
-const CustomerTab: React.FC = () => {
+const CustomerTab: React.FC<CustomerTabProps> = ({ onViewRentalsForCustomer }) => {
   const { searchQuery, setSearchQuery } = useCustomers();
 
   // State managed within CustomerTab
@@ -42,6 +46,7 @@ const CustomerTab: React.FC = () => {
       <CustomerList
         onSelectCustomer={handleSelectCustomerForDetail}
         onEditCustomer={handleOpenCustomerFormForEdit}
+        onViewRentals={onViewRentalsForCustomer}
       />
     </>
   );

--- a/src/components/dashboard/RentalsTab.tsx
+++ b/src/components/dashboard/RentalsTab.tsx
@@ -12,7 +12,11 @@ import { getRental, fetchRentalDetailsByRentalId } from '../../services/api/rent
 const RENTAL_STATUSES = ["Draft", "Pending Confirmation", "Confirmed/Booked", "Active/Rented Out", "Returned/Completed", "Overdue", "Cancelled"];
 
 
-const RentalsTab: React.FC = () => {
+interface RentalsTabProps {
+  initialCustomerIdFilter?: string | null;
+}
+
+const RentalsTab: React.FC<RentalsTabProps> = ({ initialCustomerIdFilter }) => {
   const {
     searchQuery,
     setSearchQuery,
@@ -33,6 +37,13 @@ const RentalsTab: React.FC = () => {
       fetchCustomersForSelection();
     }
   }, [customersForFilter.length, loadingCustomers, fetchCustomersForSelection]);
+
+  useEffect(() => {
+    if (initialCustomerIdFilter) {
+      setFilters({ customer_id: initialCustomerIdFilter, status: null });
+      setSearchQuery('');
+    }
+  }, [initialCustomerIdFilter, setFilters, setSearchQuery]);
 
 
   const handleOpenRentalFormForCreate = () => {


### PR DESCRIPTION
## Summary
- allow CustomerCard to trigger rental view
- plumb callbacks through CustomerList, CustomerTab, and Dashboard
- add customer filter prop for RentalsTab
- wire up state management for rental tab navigation
- optional rentals link in CustomerDetail

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684045b26b448321ad259d012ed5bdad