### PR TITLE
Add activity metadata to equipment and customers

### DIFF
--- a/src/components/CustomerCard.tsx
+++ b/src/components/CustomerCard.tsx
@@ -78,15 +78,6 @@ const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick, onEdit, 
               >
                 <Edit3 size={20} />
               </button>
-              {onViewRentals && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); onViewRentals(String(customer.customer_id)); }}
-                  className="p-1 text-green-600 hover:text-green-700 rounded-full hover:bg-light-gray-100"
-                  aria-label="View Rentals"
-                >
-                  <CalendarCheck2 size={20} />
-                </button>
-              )}
               <button
                 onClick={handleDeleteClick}
                 disabled={crudLoading}
@@ -141,6 +132,16 @@ const CustomerCard: React.FC<CustomerCardProps> = ({ customer, onClick, onEdit, 
             </div>
           </div>
         </div>
+        {onViewRentals && customer.has_active_rentals && (
+          <div className="px-6 py-3 border-t border-light-gray-100 flex justify-end">
+            <button
+              onClick={(e) => { e.stopPropagation(); onViewRentals(String(customer.customer_id)); }}
+              className="text-brand-blue border border-brand-blue text-xs px-2 py-1 rounded hover:bg-brand-blue/10"
+            >
+              View Rentals
+            </button>
+          </div>
+        )}
       </div>
 
       <ConfirmationModal

--- a/src/components/EquipmentCard.tsx
+++ b/src/components/EquipmentCard.tsx
@@ -90,13 +90,6 @@ const EquipmentCard: React.FC<EquipmentCardProps> = ({ equipment, onEdit, onView
                 <Edit3 size={20} />
               </button>
               <button
-                onClick={(e) => { e.stopPropagation(); onViewMaintenance(String(equipment.equipment_id)); }}
-                className="p-1 text-green-600 hover:text-green-700 rounded-full hover:bg-light-gray-100"
-                aria-label="View Maintenance Records"
-              >
-                <ListChecks size={20} />
-              </button>
-              <button
                 onClick={handleDeleteClick}
                 disabled={crudLoading}
                 className="p-1 text-red-600 hover:text-red-700 rounded-full hover:bg-light-gray-100 disabled:opacity-50"
@@ -153,10 +146,18 @@ const EquipmentCard: React.FC<EquipmentCardProps> = ({ equipment, onEdit, onView
             )}
           </div>
         </div>
-        <div className="p-4 mt-auto border-t border-light-gray-100">
+        <div className="p-4 mt-auto border-t border-light-gray-100 flex items-center justify-between">
             <span className={`px-2.5 py-1 text-xs font-semibold rounded-full ${getStatusColor(equipment.status)}`}>
                 {equipment.status || 'Unknown'}
             </span>
+            {onViewMaintenance && equipment.maintenance_record_count && equipment.maintenance_record_count > 0 && (
+                <button
+                    onClick={(e) => { e.stopPropagation(); onViewMaintenance(String(equipment.equipment_id)); }}
+                    className="text-brand-blue border border-brand-blue text-xs px-2 py-1 rounded hover:bg-brand-blue/10 ml-2"
+                >
+                    View Maintenance
+                </button>
+            )}
         </div>
       </div>
 

--- a/src/services/api/customers.ts
+++ b/src/services/api/customers.ts
@@ -1,11 +1,48 @@
 import { ApiResponse, PaginationParams } from '../../types';
-import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, listRecords, searchRecords } from './core';
+import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, fetchFromApi } from './core';
 
 const TABLE = 'customers';
 
-export const fetchCustomers = (params: PaginationParams): Promise<ApiResponse> => listRecords(TABLE, params);
+const buildFilterQuery = (filters?: Record<string, string | number | boolean | null>): string | undefined => {
+  if (!filters) return undefined;
+  let qString = '';
+  for (const key in filters) {
+    const value = filters[key];
+    if (value !== null && value !== undefined && String(value).trim() !== '') {
+      qString += `(${key}~equals~${String(value)})`;
+    }
+  }
+  return qString || undefined;
+};
+
+export const fetchCustomers = (params: PaginationParams): Promise<ApiResponse> => {
+  const apiParams: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    records: params.records,
+    skip: params.skip,
+    include_meta: 1,
+  };
+  const q = buildFilterQuery(params.filters);
+  if (q) apiParams.q = q;
+  return fetchFromApi('GET', apiParams);
+};
 export const createCustomer = (data: Record<string, any>): Promise<ApiResponse> => createRecordGeneric(TABLE, data);
 export const updateCustomer = (id: string, data: Record<string, any>): Promise<ApiResponse> => updateRecordGeneric(TABLE, id, data);
 export const deleteCustomer = (id: string): Promise<ApiResponse> => deleteRecord(TABLE, id);
 export const getCustomer = (id: string): Promise<ApiResponse> => getRecord(TABLE, id);
-export const searchCustomers = (queryValue: string, paginationParams?: PaginationParams): Promise<ApiResponse> => searchRecords(TABLE, queryValue, paginationParams);
+export const searchCustomers = (queryValue: string, paginationParams?: PaginationParams): Promise<ApiResponse> => {
+  const params: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    qs: queryValue,
+    include_meta: 1,
+  };
+  if (paginationParams) {
+    params.records = paginationParams.records;
+    params.skip = paginationParams.skip;
+    const q = buildFilterQuery(paginationParams.filters);
+    if (q) params.q = q;
+  }
+  return fetchFromApi('GET', params);
+};

--- a/src/services/api/equipment.ts
+++ b/src/services/api/equipment.ts
@@ -1,11 +1,48 @@
 import { ApiResponse, PaginationParams } from '../../types';
-import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, listRecords, searchRecords } from './core';
+import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, fetchFromApi } from './core';
 
 const TABLE = 'equipment';
 
-export const fetchEquipment = (params: PaginationParams): Promise<ApiResponse> => listRecords(TABLE, params);
+const buildFilterQuery = (filters?: Record<string, string | number | boolean | null>): string | undefined => {
+  if (!filters) return undefined;
+  let qString = '';
+  for (const key in filters) {
+    const value = filters[key];
+    if (value !== null && value !== undefined && String(value).trim() !== '') {
+      qString += `(${key}~equals~${String(value)})`;
+    }
+  }
+  return qString || undefined;
+};
+
+export const fetchEquipment = (params: PaginationParams): Promise<ApiResponse> => {
+  const apiParams: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    records: params.records,
+    skip: params.skip,
+    include_meta: 1,
+  };
+  const q = buildFilterQuery(params.filters);
+  if (q) apiParams.q = q;
+  return fetchFromApi('GET', apiParams);
+};
 export const createEquipment = (data: Record<string, any>): Promise<ApiResponse> => createRecordGeneric(TABLE, data);
 export const updateEquipment = (id: number, data: Record<string, any>): Promise<ApiResponse> => updateRecordGeneric(TABLE, id, data);
 export const deleteEquipment = (id: number): Promise<ApiResponse> => deleteRecord(TABLE, id);
 export const getEquipmentItem = (id: number): Promise<ApiResponse> => getRecord(TABLE, id);
-export const searchEquipment = (queryValue: string, paginationParams?: PaginationParams): Promise<ApiResponse> => searchRecords(TABLE, queryValue, paginationParams);
+export const searchEquipment = (queryValue: string, paginationParams?: PaginationParams): Promise<ApiResponse> => {
+  const params: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    qs: queryValue,
+    include_meta: 1,
+  };
+  if (paginationParams) {
+    params.records = paginationParams.records;
+    params.skip = paginationParams.skip;
+    const q = buildFilterQuery(paginationParams.filters);
+    if (q) params.q = q;
+  }
+  return fetchFromApi('GET', params);
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,8 @@ export interface Customer {
   shipping_state: string | null;
   shipping_pincode: string | null;
   registration_date: string;
+  /** Indicates if the customer currently has any active rentals */
+  has_active_rentals?: boolean;
 }
 
 export interface CustomerFormData {
@@ -44,6 +46,8 @@ export interface Equipment {
   last_maintenance_date: string | null;
   next_calibration_date: string | null;
   location: string | null;
+  /** Number of maintenance records associated with this equipment */
+  maintenance_record_count?: number;
 }
 
 export interface EquipmentFormData {


### PR DESCRIPTION
## Summary
- support optional activity fields in `Customer` and `Equipment` types
- fetch additional metadata via API calls
- expose "View Rentals" button on customers when active rentals exist
- show "View Maintenance" button on equipment when maintenance records exist

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68405a847f708321a93dbe9e472d5639