### PR TITLE
Implement conditional pincode lookup

### DIFF
--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -77,6 +77,11 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   const [numberOfDays, setNumberOfDays] = useState<number>(0);
   const [calculatedTotalAmount, setCalculatedTotalAmount] = useState<number>(0);
 
+  const [originalShippingPincode, setOriginalShippingPincode] = useState('');
+  const [originalBillingPincode, setOriginalBillingPincode] = useState('');
+
+  const shouldFetchShipping =
+    formData.shipping_pincode !== originalShippingPincode;
   const {
     loading: shippingPincodeDetailsLoading,
     error: shippingPincodeError,
@@ -84,8 +89,10 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
     city: shippingCity,
     state: shippingState,
     isAreaSelect: shippingIsAreaSelect,
-  } = usePincodeLookup(formData.shipping_pincode);
+  } = usePincodeLookup(formData.shipping_pincode, shouldFetchShipping);
 
+  const shouldFetchBilling =
+    formData.billing_pincode !== originalBillingPincode;
   const {
     loading: billingPincodeDetailsLoading,
     error: billingPincodeError,
@@ -93,7 +100,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
     city: billingCity,
     state: billingState,
     isAreaSelect: billingIsAreaSelect,
-  } = usePincodeLookup(formData.billing_pincode);
+  } = usePincodeLookup(formData.billing_pincode, shouldFetchBilling);
 
   const isEditing = !!rental;
 
@@ -139,8 +146,12 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
           default_equipment_rate: availableEquipment.find(eq => eq.equipment_id === item.equipment_id)?.rental_rate,
         })) || [],
       });
+      setOriginalShippingPincode(rental.shipping_pincode || '');
+      setOriginalBillingPincode(rental.billing_pincode || '');
     } else {
       setFormData(initialFormData);
+      setOriginalShippingPincode('');
+      setOriginalBillingPincode('');
     }
   }, [rental, availableEquipment]);
 
@@ -194,6 +205,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   }, [formData.rental_date, formData.expected_return_date, formData.rental_items]);
 
   useEffect(() => {
+    if (!shouldFetchShipping) return;
     setFormData(prev => {
       let area = prev.shipping_area;
       if (shippingAreaOptions.length === 1 && !shippingIsAreaSelect) {
@@ -215,9 +227,10 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         shipping_area: area,
       };
     });
-  }, [shippingCity, shippingState, shippingAreaOptions, shippingIsAreaSelect]);
+  }, [shippingCity, shippingState, shippingAreaOptions, shippingIsAreaSelect, shouldFetchShipping]);
 
   useEffect(() => {
+    if (!shouldFetchBilling) return;
     setFormData(prev => {
       let area = prev.billing_area;
       if (billingAreaOptions.length === 1 && !billingIsAreaSelect) {
@@ -239,7 +252,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         billing_area: area,
       };
     });
-  }, [billingCity, billingState, billingAreaOptions, billingIsAreaSelect]);
+  }, [billingCity, billingState, billingAreaOptions, billingIsAreaSelect, shouldFetchBilling]);
 
 
   const validateForm = (): boolean => {

--- a/src/utils/usePincodeLookup.ts
+++ b/src/utils/usePincodeLookup.ts
@@ -19,7 +19,10 @@ interface PincodeLookupResult {
  * Hook to fetch Indian pincode details with debounce.
  * @param pincode 6 digit pincode string
  */
-export const usePincodeLookup = (pincode: string): PincodeLookupResult => {
+export const usePincodeLookup = (
+  pincode: string,
+  enabled = true
+): PincodeLookupResult => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [areaOptions, setAreaOptions] = useState<AreaOption[]>([]);
@@ -32,6 +35,10 @@ export const usePincodeLookup = (pincode: string): PincodeLookupResult => {
   useEffect(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
+    }
+
+    if (!enabled) {
+      return;
     }
 
     if (!pincode || pincode.length !== 6 || !/^\d{6}$/.test(pincode)) {
@@ -104,7 +111,7 @@ export const usePincodeLookup = (pincode: string): PincodeLookupResult => {
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [pincode]);
+  }, [pincode, enabled]);
 
   return { loading, error, areaOptions, city, state, isAreaSelect };
 };


### PR DESCRIPTION
## Summary
- add optional `enabled` flag to `usePincodeLookup`
- store original pincodes in `RentalTransactionForm`
- skip pincode API calls when the pincode hasn't changed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68407f58d47083219a3c98c98732aaf4