### PR TITLE
Add back navigation for rentals and maintenance views

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -85,11 +85,11 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
   };
 
   const handleViewMaintenanceForEquipment = (equipmentId: string) => {
-    navigate('/maintenance', { state: { equipmentId } });
+    navigate('/maintenance', { state: { equipmentId, from: location.pathname } });
   };
 
   const handleViewRentalsForCustomer = (customerId: string) => {
-    navigate('/rentals', { state: { customerId } });
+    navigate('/rentals', { state: { customerId, from: location.pathname } });
   };
 
   useEffect(() => {

--- a/src/components/dashboard/MaintenanceTab.tsx
+++ b/src/components/dashboard/MaintenanceTab.tsx
@@ -4,7 +4,7 @@ import { useCrud } from '../../context/CrudContext';
 import MaintenanceRecordList from '../MaintenanceRecordList';
 import MaintenanceFilterBar from './MaintenanceFilterBar';
 import DeleteMaintenanceModal from './DeleteMaintenanceModal';
-import { PlusCircle, ListChecks } from 'lucide-react';
+import { PlusCircle, ListChecks, ArrowLeft } from 'lucide-react';
 import { MaintenanceRecord } from '../../types';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -34,8 +34,9 @@ const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
   const [recordToDelete, setRecordToDelete] = useState<MaintenanceRecord | null>(null);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = useState(false);
   const navigate = useNavigate();
+  const [fromPath, setFromPath] = useState<string | null>(null);
 
-  const location = useLocation() as { state?: { equipmentId?: string } };
+  const location = useLocation() as { state?: { equipmentId?: string; from?: string } };
 
   useEffect(() => {
     if (equipmentListForFilter.length === 0 && !loadingEquipmentList) {
@@ -47,6 +48,7 @@ const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
     if (location.state?.equipmentId) {
       setMaintenanceFilters({ equipment_id: location.state.equipmentId, maintenance_type: null });
       setMaintenanceSearchQuery('');
+      setFromPath(location.state.from || null);
       navigate('/maintenance', { replace: true });
     }
   }, [location.state, setMaintenanceFilters, setMaintenanceSearchQuery, navigate]);
@@ -91,6 +93,14 @@ const MaintenanceTab: React.FC<MaintenanceTabProps> = ({
 
   return (
     <>
+      {fromPath && (
+        <button
+          onClick={() => navigate(fromPath)}
+          className="mb-4 flex items-center text-brand-blue"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" /> Back
+        </button>
+      )}
       <div className="mb-6 border-b border-light-gray-200">
         <nav className="-mb-px flex space-x-4 overflow-x-auto" aria-label="Maintenance Tabs">
           {maintenanceSubTabsData.map((subTab) => (

--- a/src/components/dashboard/RentalsTab.tsx
+++ b/src/components/dashboard/RentalsTab.tsx
@@ -3,7 +3,7 @@ import { useRentalTransactions } from '../../context/RentalTransactionContext';
 import RentalTransactionList from '../rentals/RentalTransactionList';
 // import RentalTransactionDetail from '../rentals/RentalTransactionDetail'; // Keep commented if not yet implemented
 import SearchBox from '../ui/SearchBox';
-import { PlusCircle } from 'lucide-react'; // Unused icons like Filter, CalendarIcon removed
+import { PlusCircle, ArrowLeft } from 'lucide-react'; // Unused icons like Filter, CalendarIcon removed
 import { RentalTransaction } from '../../types';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -24,6 +24,7 @@ const RentalsTab: React.FC = () => {
   } = useRentalTransactions();
 
   const navigate = useNavigate();
+  const [fromPath, setFromPath] = useState<string | null>(null);
   // const [selectedRental, setSelectedRental] = useState<RentalTransaction | null>(null); // For detail view
 
   useEffect(() => {
@@ -32,12 +33,13 @@ const RentalsTab: React.FC = () => {
     }
   }, [customersForFilter.length, loadingCustomers, fetchCustomersForSelection]);
 
-  const location = useLocation() as { state?: { customerId?: string } };
+  const location = useLocation() as { state?: { customerId?: string; from?: string } };
 
   useEffect(() => {
     if (location.state?.customerId) {
       setFilters({ customer_id: location.state.customerId, status: null });
       setSearchQuery('');
+      setFromPath(location.state.from || null);
       navigate('/rentals', { replace: true });
     }
   }, [location.state, setFilters, setSearchQuery, navigate]);
@@ -63,6 +65,14 @@ const RentalsTab: React.FC = () => {
 
   return (
     <>
+      {fromPath && (
+        <button
+          onClick={() => navigate(fromPath)}
+          className="mb-4 flex items-center text-brand-blue"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" /> Back
+        </button>
+      )}
       {/* Filter UI */}
       <div className="mb-6 p-4 bg-white rounded-lg shadow">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">

--- a/src/components/pages/EquipmentDetailPage.tsx
+++ b/src/components/pages/EquipmentDetailPage.tsx
@@ -32,7 +32,7 @@ const EquipmentDetailPage: React.FC = () => {
   }
 
   const handleViewMaintenance = (equipmentId: string) => {
-    navigate('/', { state: { maintenanceEquipmentId: equipmentId } });
+    navigate('/maintenance', { state: { equipmentId, from: location.pathname } });
   };
 
   return (


### PR DESCRIPTION
## Summary
- pass current path when linking to Rentals or Maintenance
- navigate to Maintenance from equipment detail page
- show Back link in RentalsTab when filtered by customer
- show Back link in MaintenanceTab when filtered by equipment

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68408ac65efc8321b3e6046de82a3813