### PR TITLE
Use MUI date picker everywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
+        "@mui/x-date-pickers": "^8.5.0",
+        "dayjs": "^1.11.13",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1338,6 +1340,93 @@
         }
       }
     },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.5.0.tgz",
+      "integrity": "sha512-pnivJhAopuu6C4uWbEEg7b8kDdPc7Ad0ANrlDzx4qZGUj9vFcc6n+hT7/kOFnn9uceszQmb07e3Ud+g/d8Z4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.0.2",
+        "@mui/x-internals": "8.5.0",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.5.0.tgz",
+      "integrity": "sha512-Ef4KJij1pBGk6/xILyVZHf76tcuRpJIX30k4Ghklsd5QJujZ9ENCGAjvd7aWRAFAs5p3ffn0H8UDESoIcroj1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2446,6 +2535,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
+    "@mui/x-date-pickers": "^8.5.0",
+    "dayjs": "^1.11.13",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { CustomerProvider } from './context/CustomerContext';
 import { CrudProvider } from './context/CrudContext';
 import { EquipmentProvider } from './context/EquipmentContext';
@@ -29,8 +31,9 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <CrudProvider>
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <CssBaseline />
+        <CrudProvider>
       <CustomerProvider>
         <EquipmentProvider>
           <EquipmentCategoryProvider>
@@ -82,6 +85,7 @@ function App() {
         </EquipmentProvider>
       </CustomerProvider>
     </CrudProvider>
+      </LocalizationProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/equipment/EquipmentDatesLocation.tsx
+++ b/src/components/equipment/EquipmentDatesLocation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { EquipmentFormData } from '../../types';
 import { CalendarDays, MapPin, Wrench } from 'lucide-react';
 
+import DatePickerField from "../ui/DatePickerField";
 interface Props {
   formData: EquipmentFormData;
   formErrors: Partial<Record<keyof EquipmentFormData, string>>;
@@ -23,7 +24,11 @@ const EquipmentDatesLocation: React.FC<Props> = ({
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Dates & Location</legend>
     <div>
       <label htmlFor="purchase_date" className={labelClass}>Purchase Date</label>
-      <input type="date" name="purchase_date" id="purchase_date" value={formData.purchase_date || ''} onChange={handleChange} className={inputClass} />
+      <DatePickerField
+        name="purchase_date"
+        value={formData.purchase_date || ''}
+        onChange={handleChange}
+      />
       {formErrors.purchase_date && <p className="text-xs text-red-500 mt-1">{formErrors.purchase_date}</p>}
     </div>
     <div>
@@ -37,14 +42,22 @@ const EquipmentDatesLocation: React.FC<Props> = ({
       <label htmlFor="last_maintenance_date" className={labelClass}>Last Maintenance Date</label>
       <div className="mt-1 relative rounded-md shadow-sm">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Wrench className={iconClass} /></div>
-        <input type="date" name="last_maintenance_date" id="last_maintenance_date" value={formData.last_maintenance_date || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+        <DatePickerField
+          name="last_maintenance_date"
+          value={formData.last_maintenance_date || ''}
+          onChange={handleChange}
+        />
       </div>
     </div>
     <div>
       <label htmlFor="next_calibration_date" className={labelClass}>Next Calibration Date</label>
       <div className="mt-1 relative rounded-md shadow-sm">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><CalendarDays className={iconClass} /></div>
-        <input type="date" name="next_calibration_date" id="next_calibration_date" value={formData.next_calibration_date || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
+        <DatePickerField
+          name="next_calibration_date"
+          value={formData.next_calibration_date || ''}
+          onChange={handleChange}
+        />
       </div>
     </div>
   </fieldset>

--- a/src/components/maintenance/MaintenanceRecordInfo.tsx
+++ b/src/components/maintenance/MaintenanceRecordInfo.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { MaintenanceRecordFormData, Equipment } from '../../types';
 import { Loader2, Package, CalendarDays } from 'lucide-react';
 
+import DatePickerField from "../ui/DatePickerField";
+
 interface Props {
   formData: MaintenanceRecordFormData;
   formErrors: Partial<Record<keyof MaintenanceRecordFormData, string>>;
@@ -61,18 +63,12 @@ const MaintenanceRecordInfo: React.FC<Props> = ({
         <label htmlFor="maintenance_date" className={labelClass}>
           Maintenance Date <span className="text-red-500">*</span>
         </label>
-        <div className="mt-1 relative rounded-md shadow-sm">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <CalendarDays className={iconClass} />
-          </div>
-          <input
-            type="date"
-            id="maintenance_date"
+        <div className="mt-1">
+          <DatePickerField
             name="maintenance_date"
             value={formData.maintenance_date}
             onChange={handleChange}
             required
-            className={`${inputClass} pl-10`}
           />
         </div>
         {formErrors.maintenance_date && <p className="text-xs text-red-500 mt-1">{formErrors.maintenance_date}</p>}

--- a/src/components/payments/PaymentForm.tsx
+++ b/src/components/payments/PaymentForm.tsx
@@ -3,6 +3,7 @@ import { Payment, PaymentFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, CalendarCheck2, IndianRupee } from 'lucide-react';
 
+import DatePickerField from "../ui/DatePickerField";
 interface PaymentFormProps {
   payment?: Payment | null;
   onSave: () => void;
@@ -165,13 +166,10 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
           <label htmlFor="payment_date" className="block text-sm font-medium text-dark-text mb-1">
             Date
           </label>
-          <input
-            type="date"
-            id="payment_date"
+          <DatePickerField
             name="payment_date"
             value={formData.payment_date}
             onChange={handleChange}
-            className={inputClass}
           />
           {formErrors.payment_date && <p className="text-red-600 text-sm mt-1">{formErrors.payment_date}</p>}
         </div>

--- a/src/components/rentals/RentalStatusDates.tsx
+++ b/src/components/rentals/RentalStatusDates.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CalendarDays, ChevronDown } from 'lucide-react';
 import { RentalTransactionFormData } from '../../types';
 
+import DatePickerField from "../ui/DatePickerField";
 interface Props {
   data: Pick<RentalTransactionFormData, 'rental_date' | 'expected_return_date' | 'status'>;
   numberOfDays: number;
@@ -31,13 +32,10 @@ const RentalStatusDates: React.FC<Props> = ({
       <label htmlFor="rental_date" className={labelClass}>
         Rental Date <span className="text-red-500">*</span>
       </label>
-      <input
-        type="date"
+      <DatePickerField
         name="rental_date"
-        id="rental_date"
         value={data.rental_date}
         onChange={handleChange}
-        className={inputClass}
         required
       />
       {errors.rental_date && (
@@ -49,13 +47,10 @@ const RentalStatusDates: React.FC<Props> = ({
       <label htmlFor="expected_return_date" className={labelClass}>
         Expected Return Date <span className="text-red-500">*</span>
       </label>
-      <input
-        type="date"
+      <DatePickerField
         name="expected_return_date"
-        id="expected_return_date"
         value={data.expected_return_date || ''}
         onChange={handleChange}
-        className={inputClass}
         required
       />
       {errors.expected_return_date && (

--- a/src/components/ui/DatePickerField.tsx
+++ b/src/components/ui/DatePickerField.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+
+interface DatePickerFieldProps {
+  label?: string;
+  name: string;
+  value: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  required?: boolean;
+}
+
+const DatePickerField: React.FC<DatePickerFieldProps> = ({ label, name, value, onChange, required }) => {
+  const handleChange = (date: Dayjs | null) => {
+    const syntheticEvent = {
+      target: { name, value: date ? date.format('YYYY-MM-DD') : '' }
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    onChange(syntheticEvent);
+  };
+
+  return (
+    <DatePicker
+      label={label}
+      value={value ? dayjs(value) : null}
+      onChange={handleChange}
+      slotProps={{ textField: { fullWidth: true, name, id: name, required } }}
+    />
+  );
+};
+
+export default DatePickerField;


### PR DESCRIPTION
## Summary
- add `@mui/x-date-pickers` and `dayjs`
- wrap app with `LocalizationProvider`
- add shared `DatePickerField` component
- replace native date inputs with MUI `<DatePicker>`

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68413aaebbc48321aa1c69d0590e64bb