### PR TITLE
Introduce Autocomplete component

### DIFF
--- a/src/components/MaintenanceRecordForm.tsx
+++ b/src/components/MaintenanceRecordForm.tsx
@@ -6,6 +6,7 @@ import { MaintenanceRecordFormData } from '../types';
 import { useMaintenanceRecords } from '../context/MaintenanceRecordContext'; // To get equipment list
 import { useCrud } from '../context/CrudContext'; // To get loading state from CRUD operations
 import { Save, X, Loader2, Wrench, ChevronDown } from 'lucide-react';
+import AutocompleteField, { AutocompleteOption } from './ui/AutocompleteField';
 import MaintenanceRecordInfo from './maintenance/MaintenanceRecordInfo';
 import MaintenanceRecordExtra from './maintenance/MaintenanceRecordExtra';
 import dayjs from 'dayjs';
@@ -122,7 +123,7 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
     return Object.keys(errors).length === 0;
   };
 
-  const handleDropdownChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleDropdownChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const value = e.target.value;
     setSelectedDropdownMaintenanceType(value);
     if (value !== CUSTOM_MAINTENANCE_TYPE_KEY) {
@@ -198,21 +199,20 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               <label htmlFor="maintenance_type_dropdown" className={labelClass}>Maintenance Type</label>
               <div className="mt-1 relative rounded-md shadow-sm">
                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Wrench className={iconClass} /></div>
-                <select
-                  id="maintenance_type_dropdown"
-                  name="maintenance_type_dropdown"
-                  value={selectedDropdownMaintenanceType}
-                  onChange={handleDropdownChange} // Specific handler for this dropdown
-                  className={`${inputClass} pl-10 pr-8 appearance-none`}
-                >
-                  <option value="">Select Type...</option>
-                  {PREDEFINED_MAINTENANCE_TYPES.map(type => (
-                    <option key={type} value={type}>{type}</option>
-                  ))}
-                  <option value={CUSTOM_MAINTENANCE_TYPE_KEY}>Other (Specify)</option>
-                </select>
-                <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                <div className="pl-10">
+                  <AutocompleteField
+                    name="maintenance_type_dropdown"
+                    value={selectedDropdownMaintenanceType}
+                    onChange={handleDropdownChange as React.ChangeEventHandler<HTMLInputElement>}
+                    options={[
+                      ...PREDEFINED_MAINTENANCE_TYPES.map(t => ({ label: t, value: t })),
+                      { label: 'Other (Specify)', value: CUSTOM_MAINTENANCE_TYPE_KEY },
+                    ]}
+                    placeholder="Select Type..."
+                  />
+                  <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
                     <ChevronDown className="h-4 w-4 text-gray-400" />
+                  </div>
                 </div>
               </div>
               {formErrors.maintenance_type && selectedDropdownMaintenanceType !== CUSTOM_MAINTENANCE_TYPE_KEY && <p className="text-xs text-red-500 mt-1">{formErrors.maintenance_type}</p>}

--- a/src/components/customers/CustomerShippingInfoSection.tsx
+++ b/src/components/customers/CustomerShippingInfoSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CustomerFormData } from '../../types';
 import { Loader2 } from 'lucide-react';
+import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
 
 interface AreaOption {
   value: string;
@@ -29,7 +30,13 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
   isAreaSelect,
   inputClass,
   labelClass,
-}) => (
+}) => {
+  const areaSelectOptions: AutocompleteOption[] = areaOptions.map(opt => ({
+    label: opt.label,
+    value: opt.value,
+  }));
+
+  return (
   <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full">Shipping Information</legend>
     <div className="md:col-span-2">
@@ -62,10 +69,13 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
     <div>
       <label htmlFor="shipping_area" className={labelClass}>Area</label>
       {isAreaSelect ? (
-        <select name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass}>
-          <option value="">Select Area</option>
-          {areaOptions.map(opt => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-        </select>
+        <AutocompleteField
+          name="shipping_area"
+          value={formData.shipping_area || ''}
+          onChange={handleChange}
+          options={areaSelectOptions}
+          placeholder="Select Area"
+        />
       ) : (
         <input type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={areaOptions.length > 0 && !isAreaSelect} />
       )}
@@ -81,6 +91,7 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
       <input type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
     </div>
   </fieldset>
-);
+  );
+};
 
 export default CustomerShippingInfoSection;

--- a/src/components/equipment/EquipmentBasicInfo.tsx
+++ b/src/components/equipment/EquipmentBasicInfo.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { EquipmentFormData, EquipmentCategory } from '../../types';
 import { Loader2, Package, Info, Tag } from 'lucide-react';
+import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
 
 interface Props {
   formData: EquipmentFormData;
@@ -24,7 +25,13 @@ const EquipmentBasicInfo: React.FC<Props> = ({
   inputClass,
   labelClass,
   iconClass,
-}) => (
+}) => {
+  const categoryOptions: AutocompleteOption[] = equipmentCategories.map(cat => ({
+    label: cat.category_name,
+    value: String(cat.category_id),
+  }));
+
+  return (
   <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Basic Information</legend>
     <div className="md:col-span-2">
@@ -50,20 +57,21 @@ const EquipmentBasicInfo: React.FC<Props> = ({
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           {categoriesLoading ? <Loader2 className={`${iconClass} animate-spin`} /> : <Tag className={iconClass} />}
         </div>
-        <select
-          name="category_id"
-          id="category_id"
-          value={formData.category_id === undefined ? '' : String(formData.category_id)}
-          onChange={handleChange}
-          className={`${inputClass} pl-10`}
-          disabled={categoriesLoading || !!categoriesError}
-        >
-          <option value="">{categoriesLoading ? 'Loading...' : 'Select Category'}</option>
-          {equipmentCategories.map(cat => <option key={cat.category_id} value={String(cat.category_id)}>{cat.category_name}</option>)}
-        </select>
+        <div className="pl-10">
+          <AutocompleteField
+            name="category_id"
+            value={formData.category_id === undefined ? '' : String(formData.category_id)}
+            onChange={handleChange}
+            options={categoryOptions}
+            loading={categoriesLoading}
+            disabled={categoriesLoading || !!categoriesError}
+            placeholder={categoriesLoading ? 'Loading...' : 'Select Category'}
+          />
+        </div>
       </div>
     </div>
   </fieldset>
-);
+  );
+};
 
 export default EquipmentBasicInfo;

--- a/src/components/maintenance/MaintenanceRecordInfo.tsx
+++ b/src/components/maintenance/MaintenanceRecordInfo.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { MaintenanceRecordFormData, Equipment } from '../../types';
 import { Loader2, Package, CalendarDays } from 'lucide-react';
 
-import DatePickerField from "../ui/DatePickerField";
+import DatePickerField from '../ui/DatePickerField';
+import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
 
 interface Props {
   formData: MaintenanceRecordFormData;
@@ -38,23 +39,20 @@ const MaintenanceRecordInfo: React.FC<Props> = ({
               <Package className={iconClass} />
             )}
           </div>
-          <select
-            id="equipment_id"
-            name="equipment_id"
-            value={formData.equipment_id}
-            onChange={handleChange}
-            required
-            disabled={loadingEquipment}
-            className={`${inputClass} pl-10`}
-          >
-            <option value="">{loadingEquipment ? 'Loading Equipment...' : 'Select Equipment'}</option>
-            {!loadingEquipment &&
-              equipmentList.map((equipment) => (
-                <option key={equipment.equipment_id} value={String(equipment.equipment_id)}>
-                  {equipment.equipment_name} ({equipment.serial_number || 'N/A'})
-                </option>
-              ))}
-          </select>
+          <div className="pl-10">
+            <AutocompleteField
+              name="equipment_id"
+              value={formData.equipment_id}
+              onChange={handleChange}
+              options={equipmentList.map((equipment) => ({
+                label: `${equipment.equipment_name} (${equipment.serial_number || 'N/A'})`,
+                value: String(equipment.equipment_id),
+              }))}
+              loading={loadingEquipment}
+              disabled={loadingEquipment}
+              placeholder={loadingEquipment ? 'Loading Equipment...' : 'Select Equipment'}
+            />
+          </div>
         </div>
         {formErrors.equipment_id && <p className="text-xs text-red-500 mt-1">{formErrors.equipment_id}</p>}
       </div>

--- a/src/components/ui/AutocompleteField.tsx
+++ b/src/components/ui/AutocompleteField.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+
+export interface AutocompleteOption {
+  label: string;
+  value: string | number;
+}
+
+interface AutocompleteFieldProps {
+  name: string;
+  id?: string;
+  value: string | number | undefined;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  options: AutocompleteOption[];
+  loading?: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
+  name,
+  id = name,
+  value,
+  onChange,
+  options,
+  loading = false,
+  disabled = false,
+  placeholder,
+}) => {
+  const selectedOption =
+    options.find((opt) => String(opt.value) === String(value)) || null;
+
+  const handleChange = (_: any, newValue: AutocompleteOption | null) => {
+    const syntheticEvent = {
+      target: {
+        name,
+        value: newValue ? newValue.value : '',
+      },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    onChange(syntheticEvent);
+  };
+
+  return (
+    <Autocomplete
+      options={options}
+      getOptionLabel={(option) => option.label}
+      value={selectedOption}
+      onChange={handleChange}
+      loading={loading}
+      disabled={disabled}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          name={name}
+          id={id}
+          placeholder={placeholder}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default AutocompleteField;


### PR DESCRIPTION
## Summary
- create a reusable `AutocompleteField` component using Material UI
- swap select elements for Autocomplete in several forms

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6841476e9d608321861c13c5ee231051