### PR TITLE
Use MUI text field wrapper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,16 @@ import NotFound from './components/pages/NotFound';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const theme = createTheme();
+  const theme = createTheme({
+    components: {
+      MuiTextField: {
+        defaultProps: {
+          variant: 'outlined',
+          InputLabelProps: { shrink: true },
+        },
+      },
+    },
+  });
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/customers/CustomerPersonalInfoSection.tsx
+++ b/src/components/customers/CustomerPersonalInfoSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CustomerFormData } from '../../types';
+import OutlinedTextField from '../ui/OutlinedTextField';
 
 interface Props {
   formData: CustomerFormData;
@@ -13,9 +14,16 @@ const CustomerPersonalInfoSection: React.FC<Props> = ({ formData, formErrors, ha
   <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full">Personal Information</legend>
     <div>
-      <label htmlFor="full_name" className={labelClass}>Full Name <span className="text-red-500">*</span></label>
-      <input type="text" name="full_name" id="full_name" value={formData.full_name} onChange={handleChange} className={inputClass} required />
-      {formErrors.full_name && <p className="text-xs text-red-500 mt-1">{formErrors.full_name}</p>}
+      <OutlinedTextField
+        label="Full Name"
+        name="full_name"
+        id="full_name"
+        value={formData.full_name}
+        onChange={handleChange}
+        required
+        error={!!formErrors.full_name}
+        helperText={formErrors.full_name}
+      />
     </div>
     <div>
       <label htmlFor="email" className={labelClass}>Email</label>

--- a/src/components/ui/OutlinedTextField.tsx
+++ b/src/components/ui/OutlinedTextField.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import TextField, { TextFieldProps } from '@mui/material/TextField';
+
+/**
+ * A wrapper around MUI's TextField that applies the outlined variant
+ * and keeps the label positioned in the top left.
+ */
+const OutlinedTextField: React.FC<TextFieldProps> = (props) => {
+  return (
+    <TextField
+      {...props}
+      variant="outlined"
+      fullWidth
+      InputLabelProps={{ shrink: true, ...(props.InputLabelProps || {}) }}
+    />
+  );
+};
+
+export default OutlinedTextField;


### PR DESCRIPTION
## Summary
- configure default MUI text field settings
- add `OutlinedTextField` UI component
- switch full name input in customer info section to the new field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68414b29d5ac8321b931d5ef0392f24a