### PR TITLE
Consistent outlined inputs across forms

### DIFF
--- a/src/components/MaintenanceRecordForm.tsx
+++ b/src/components/MaintenanceRecordForm.tsx
@@ -7,6 +7,7 @@ import { useMaintenanceRecords } from '../context/MaintenanceRecordContext'; // 
 import { useCrud } from '../context/CrudContext'; // To get loading state from CRUD operations
 import { Save, X, Loader2, Wrench, ChevronDown } from 'lucide-react';
 import AutocompleteField, { AutocompleteOption } from './ui/AutocompleteField';
+import OutlinedTextField from './ui/OutlinedTextField';
 import MaintenanceRecordInfo from './maintenance/MaintenanceRecordInfo';
 import MaintenanceRecordExtra from './maintenance/MaintenanceRecordExtra';
 import dayjs from 'dayjs';
@@ -221,12 +222,12 @@ const MaintenanceRecordForm: React.FC<MaintenanceRecordFormProps> = ({
               {selectedDropdownMaintenanceType === CUSTOM_MAINTENANCE_TYPE_KEY && (
                 <div className="mt-2">
                   <label htmlFor="custom_maintenance_type" className={`${labelClass} text-xs`}>Specify Other Type:</label>
-                  <input
+                  <OutlinedTextField
                     type="text"
                     id="custom_maintenance_type"
                     name="custom_maintenance_type"
                     value={customMaintenanceTypeValue}
-                    onChange={handleCustomInputChange} // Specific handler
+                    onChange={handleCustomInputChange as React.ChangeEventHandler<HTMLInputElement>}
                     placeholder="Enter custom maintenance type"
                     className={`${inputClass} pl-3`}
                   />

--- a/src/components/customers/CustomerPersonalInfoSection.tsx
+++ b/src/components/customers/CustomerPersonalInfoSection.tsx
@@ -26,22 +26,48 @@ const CustomerPersonalInfoSection: React.FC<Props> = ({ formData, formErrors, ha
       />
     </div>
     <div>
-      <label htmlFor="email" className={labelClass}>Email</label>
-      <input type="email" name="email" id="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
-      {formErrors.email && <p className="text-xs text-red-500 mt-1">{formErrors.email}</p>}
+      <OutlinedTextField
+        label="Email"
+        type="email"
+        name="email"
+        id="email"
+        value={formData.email || ''}
+        onChange={handleChange}
+        error={!!formErrors.email}
+        helperText={formErrors.email}
+      />
     </div>
     <div>
-      <label htmlFor="mobile_number_1" className={labelClass}>Mobile Number 1</label>
-      <input type="tel" name="mobile_number_1" id="mobile_number_1" value={formData.mobile_number_1 || ''} onChange={handleChange} className={inputClass} />
-      {formErrors.mobile_number_1 && <p className="text-xs text-red-500 mt-1">{formErrors.mobile_number_1}</p>}
+      <OutlinedTextField
+        label="Mobile Number 1"
+        type="tel"
+        name="mobile_number_1"
+        id="mobile_number_1"
+        value={formData.mobile_number_1 || ''}
+        onChange={handleChange}
+        error={!!formErrors.mobile_number_1}
+        helperText={formErrors.mobile_number_1}
+      />
     </div>
     <div>
-      <label htmlFor="mobile_number_2" className={labelClass}>Mobile Number 2</label>
-      <input type="tel" name="mobile_number_2" id="mobile_number_2" value={formData.mobile_number_2 || ''} onChange={handleChange} className={inputClass} />
+      <OutlinedTextField
+        label="Mobile Number 2"
+        type="tel"
+        name="mobile_number_2"
+        id="mobile_number_2"
+        value={formData.mobile_number_2 || ''}
+        onChange={handleChange}
+      />
     </div>
     <div>
-      <label htmlFor="mobile_number_3" className={labelClass}>Mobile Number 3</label>
-      <input type="tel" name="mobile_number_3" id="mobile_number_3" value={formData.mobile_number_3 || ''} onChange={handleChange} className={inputClass} />
+      <OutlinedTextField
+        label="Mobile Number 3"
+        type="tel"
+        name="mobile_number_3"
+        id="mobile_number_3"
+        value={formData.mobile_number_3 || ''}
+        onChange={handleChange}
+      />
     </div>
   </fieldset>
 );

--- a/src/components/customers/CustomerShippingInfoSection.tsx
+++ b/src/components/customers/CustomerShippingInfoSection.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { CustomerFormData } from '../../types';
 import { Loader2 } from 'lucide-react';
 import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface AreaOption {
   value: string;
@@ -40,34 +42,38 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
   <fieldset className="grid grid-cols-1 gap-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full">Shipping Information</legend>
     <div className="md:col-span-2">
-      <label htmlFor="shipping_address" className={labelClass}>Address Line</label>
-      <textarea name="shipping_address" id="shipping_address" value={formData.shipping_address || ''} onChange={handleChange} rows={2} className={inputClass}></textarea>
+      <OutlinedTextField
+        label="Address Line"
+        name="shipping_address"
+        id="shipping_address"
+        value={formData.shipping_address || ''}
+        onChange={handleChange}
+        multiline
+        rows={2}
+      />
     </div>
 
     <div>
-      <label htmlFor="shipping_pincode" className={labelClass}>Pincode</label>
-      <div className="relative">
-        <input
-          type="text"
-          name="shipping_pincode"
-          id="shipping_pincode"
-          value={formData.shipping_pincode || ''}
-          onChange={handleChange}
-          className={inputClass}
-          maxLength={6}
-        />
-        {pincodeDetailsLoading && (
-          <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-            <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-          </div>
-        )}
-      </div>
-      {formErrors.shipping_pincode && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_pincode}</p>}
-      {pincodeError && <p className="text-xs text-red-500 mt-1">{pincodeError}</p>}
+      <OutlinedTextField
+        label="Pincode"
+        name="shipping_pincode"
+        id="shipping_pincode"
+        value={formData.shipping_pincode || ''}
+        onChange={handleChange}
+        inputProps={{ maxLength: 6 }}
+        error={!!formErrors.shipping_pincode || !!pincodeError}
+        helperText={formErrors.shipping_pincode || pincodeError}
+        InputProps={{
+          endAdornment: pincodeDetailsLoading ? (
+            <InputAdornment position="end">
+              <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+            </InputAdornment>
+          ) : undefined,
+        }}
+      />
     </div>
 
     <div>
-      <label htmlFor="shipping_area" className={labelClass}>Area</label>
       {isAreaSelect ? (
         <AutocompleteField
           name="shipping_area"
@@ -77,18 +83,37 @@ const CustomerShippingInfoSection: React.FC<Props> = ({
           placeholder="Select Area"
         />
       ) : (
-        <input type="text" name="shipping_area" id="shipping_area" value={formData.shipping_area || ''} onChange={handleChange} className={inputClass} readOnly={areaOptions.length > 0 && !isAreaSelect} />
+        <OutlinedTextField
+          label="Area"
+          name="shipping_area"
+          id="shipping_area"
+          value={formData.shipping_area || ''}
+          onChange={handleChange}
+          InputProps={{ readOnly: areaOptions.length > 0 && !isAreaSelect }}
+        />
       )}
       {formErrors.shipping_area && <p className="text-xs text-red-500 mt-1">{formErrors.shipping_area}</p>}
     </div>
 
     <div>
-      <label htmlFor="shipping_city" className={labelClass}>City</label>
-      <input type="text" name="shipping_city" id="shipping_city" value={formData.shipping_city || ''} onChange={handleChange} className={inputClass} readOnly />
+      <OutlinedTextField
+        label="City"
+        name="shipping_city"
+        id="shipping_city"
+        value={formData.shipping_city || ''}
+        onChange={handleChange}
+        InputProps={{ readOnly: true }}
+      />
     </div>
     <div>
-      <label htmlFor="shipping_state" className={labelClass}>State</label>
-      <input type="text" name="shipping_state" id="shipping_state" value={formData.shipping_state || ''} onChange={handleChange} className={inputClass} readOnly />
+      <OutlinedTextField
+        label="State"
+        name="shipping_state"
+        id="shipping_state"
+        value={formData.shipping_state || ''}
+        onChange={handleChange}
+        InputProps={{ readOnly: true }}
+      />
     </div>
   </fieldset>
   );

--- a/src/components/equipment/EquipmentBasicInfo.tsx
+++ b/src/components/equipment/EquipmentBasicInfo.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { EquipmentFormData, EquipmentCategory } from '../../types';
 import { Loader2, Package, Info, Tag } from 'lucide-react';
 import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface Props {
   formData: EquipmentFormData;
@@ -35,20 +37,42 @@ const EquipmentBasicInfo: React.FC<Props> = ({
   <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Basic Information</legend>
     <div className="md:col-span-2">
-      <label htmlFor="equipment_name" className={labelClass}>Equipment Name <span className="text-red-500">*</span></label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Package className={iconClass} /></div>
-        <input type="text" name="equipment_name" id="equipment_name" value={formData.equipment_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
-      </div>
-      {formErrors.equipment_name && <p className="text-xs text-red-500 mt-1">{formErrors.equipment_name}</p>}
+      <OutlinedTextField
+        label="Equipment Name"
+        name="equipment_name"
+        id="equipment_name"
+        value={formData.equipment_name}
+        onChange={handleChange}
+        required
+        error={!!formErrors.equipment_name}
+        helperText={formErrors.equipment_name}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Package className={iconClass} />
+            </InputAdornment>
+          ),
+        }}
+      />
     </div>
 
     <div className="md:col-span-2">
-      <label htmlFor="description" className={labelClass}>Description</label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-        <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={3} className={`${inputClass} pl-10`}></textarea>
-      </div>
+      <OutlinedTextField
+        label="Description"
+        name="description"
+        id="description"
+        value={formData.description || ''}
+        onChange={handleChange}
+        multiline
+        rows={3}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Info className={iconClass} />
+            </InputAdornment>
+          ),
+        }}
+      />
     </div>
 
     <div>

--- a/src/components/equipment/EquipmentDatesLocation.tsx
+++ b/src/components/equipment/EquipmentDatesLocation.tsx
@@ -3,6 +3,8 @@ import { EquipmentFormData } from '../../types';
 import { CalendarDays, MapPin, Wrench } from 'lucide-react';
 
 import DatePickerField from "../ui/DatePickerField";
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 interface Props {
   formData: EquipmentFormData;
   formErrors: Partial<Record<keyof EquipmentFormData, string>>;
@@ -32,11 +34,20 @@ const EquipmentDatesLocation: React.FC<Props> = ({
       {formErrors.purchase_date && <p className="text-xs text-red-500 mt-1">{formErrors.purchase_date}</p>}
     </div>
     <div>
-      <label htmlFor="location" className={labelClass}>Current Location</label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><MapPin className={iconClass} /></div>
-        <input type="text" name="location" id="location" value={formData.location || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
-      </div>
+      <OutlinedTextField
+        label="Current Location"
+        name="location"
+        id="location"
+        value={formData.location || ''}
+        onChange={handleChange}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <MapPin className={iconClass} />
+            </InputAdornment>
+          ),
+        }}
+      />
     </div>
     <div>
       <label htmlFor="last_maintenance_date" className={labelClass}>Last Maintenance Date</label>

--- a/src/components/equipment/EquipmentFinancial.tsx
+++ b/src/components/equipment/EquipmentFinancial.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { EquipmentFormData } from '../../types';
 import { IndianRupee, Tag } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import AutocompleteField, { AutocompleteOption } from '../ui/AutocompleteField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface Props {
   formData: EquipmentFormData;
@@ -22,27 +25,52 @@ const EquipmentFinancial: React.FC<Props> = ({
   inputClass,
   labelClass,
   iconClass,
-}) => (
+}) => {
+  const statusOptions: AutocompleteOption[] = equipmentStatuses.map((s) => ({
+    label: s,
+    value: s,
+  }));
+
+  return (
   <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Financials & Status</legend>
     <div className={isEditing ? 'md:col-span-2' : ''}>
-      <label htmlFor="rental_rate" className={labelClass}>Rental Rate (₹ per unit/day)</label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><IndianRupee className={iconClass} /></div>
-        <input type="number" name="rental_rate" id="rental_rate" value={formData.rental_rate || ''} onChange={handleChange} className={`${inputClass} pl-10`} step="0.01" min="0" />
-      </div>
-      {formErrors.rental_rate && <p className="text-xs text-red-500 mt-1">{formErrors.rental_rate}</p>}
+      <OutlinedTextField
+        label="Rental Rate (₹ per unit/day)"
+        type="number"
+        name="rental_rate"
+        id="rental_rate"
+        value={formData.rental_rate || ''}
+        onChange={handleChange}
+        error={!!formErrors.rental_rate}
+        helperText={formErrors.rental_rate}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <IndianRupee className={iconClass} />
+            </InputAdornment>
+          ),
+          inputProps: { step: 0.01, min: 0 },
+        }}
+      />
     </div>
     <div>
       <label htmlFor="status" className={labelClass}>Status</label>
       <div className="mt-1 relative rounded-md shadow-sm">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Tag className={iconClass} /></div>
-        <select name="status" id="status" value={formData.status || ''} onChange={handleChange} className={`${inputClass} pl-10`}>
-          {equipmentStatuses.map(s => <option key={s} value={s}>{s}</option>)}
-        </select>
+        <div className="pl-10">
+          <AutocompleteField
+            name="status"
+            value={formData.status || ''}
+            onChange={handleChange}
+            options={statusOptions}
+            placeholder="Select Status"
+          />
+        </div>
       </div>
     </div>
   </fieldset>
-);
+  );
+};
 
 export default EquipmentFinancial;

--- a/src/components/equipment/EquipmentIdentification.tsx
+++ b/src/components/equipment/EquipmentIdentification.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { EquipmentFormData } from '../../types';
 import { Hash, Layers } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface Props {
   formData: EquipmentFormData;
@@ -24,29 +26,61 @@ const EquipmentIdentification: React.FC<Props> = ({
   <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Identification & Quantity</legend>
     <div>
-      <label htmlFor="make" className={labelClass}>Make/Brand</label>
-      <input type="text" name="make" id="make" value={formData.make || ''} onChange={handleChange} className={inputClass} />
+      <OutlinedTextField
+        label="Make/Brand"
+        name="make"
+        id="make"
+        value={formData.make || ''}
+        onChange={handleChange}
+      />
     </div>
     <div>
-      <label htmlFor="model" className={labelClass}>Model</label>
-      <input type="text" name="model" id="model" value={formData.model || ''} onChange={handleChange} className={inputClass} />
+      <OutlinedTextField
+        label="Model"
+        name="model"
+        id="model"
+        value={formData.model || ''}
+        onChange={handleChange}
+      />
     </div>
     <div>
-      <label htmlFor="serial_number" className={labelClass}>Serial Number {isEditing ? '(Editing specific item)' : '(Base for quantity)'}</label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Hash className={iconClass} /></div>
-        <input type="text" name="serial_number" id="serial_number" value={formData.serial_number || ''} onChange={handleChange} className={`${inputClass} pl-10`} />
-      </div>
-      {formErrors.serial_number && <p className="text-xs text-red-500 mt-1">{formErrors.serial_number}</p>}
+      <OutlinedTextField
+        label={`Serial Number ${isEditing ? '(Editing specific item)' : '(Base for quantity)'}`}
+        name="serial_number"
+        id="serial_number"
+        value={formData.serial_number || ''}
+        onChange={handleChange}
+        error={!!formErrors.serial_number}
+        helperText={formErrors.serial_number}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Hash className={iconClass} />
+            </InputAdornment>
+          ),
+        }}
+      />
     </div>
     {!isEditing && (
       <div>
-        <label htmlFor="quantity" className={labelClass}>Quantity</label>
-        <div className="mt-1 relative rounded-md shadow-sm">
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Layers className={iconClass} /></div>
-          <input type="number" name="quantity" id="quantity" value={formData.quantity || '1'} onChange={handleChange} className={`${inputClass} pl-10`} min="1" />
-        </div>
-        {formErrors.quantity && <p className="text-xs text-red-500 mt-1">{formErrors.quantity}</p>}
+        <OutlinedTextField
+          label="Quantity"
+          type="number"
+          name="quantity"
+          id="quantity"
+          value={formData.quantity || '1'}
+          onChange={handleChange}
+          error={!!formErrors.quantity}
+          helperText={formErrors.quantity}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Layers className={iconClass} />
+              </InputAdornment>
+            ),
+            inputProps: { min: 1 },
+          }}
+        />
       </div>
     )}
   </fieldset>

--- a/src/components/maintenance/MaintenanceRecordExtra.tsx
+++ b/src/components/maintenance/MaintenanceRecordExtra.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { MaintenanceRecordFormData } from '../../types';
 import { User, IndianRupee, Info } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface Props {
   formData: MaintenanceRecordFormData;
@@ -26,7 +28,7 @@ const MaintenanceRecordExtra: React.FC<Props> = ({
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <User className={iconClass} />
           </div>
-          <input
+          <OutlinedTextField
             type="text"
             id="technician"
             name="technician"
@@ -43,16 +45,22 @@ const MaintenanceRecordExtra: React.FC<Props> = ({
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <IndianRupee className={iconClass} />
           </div>
-          <input
+          <OutlinedTextField
             type="number"
             id="cost"
             name="cost"
             value={formData.cost || ''}
             onChange={handleChange}
-            step="0.01"
-            min="0"
-            placeholder="0.00"
             className={`${inputClass} pl-10`}
+            inputProps={{ step: '0.01', min: '0' }}
+            placeholder="0.00"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <IndianRupee className={iconClass} />
+                </InputAdornment>
+              ),
+            }}
           />
         </div>
         {formErrors.cost && <p className="text-xs text-red-500 mt-1">{formErrors.cost}</p>}
@@ -64,14 +72,22 @@ const MaintenanceRecordExtra: React.FC<Props> = ({
           <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none">
             <Info className={iconClass} />
           </div>
-          <textarea
+          <OutlinedTextField
             id="notes"
             name="notes"
             value={formData.notes || ''}
             onChange={handleChange}
+            multiline
             rows={3}
             className={`${inputClass} pl-10`}
-          ></textarea>
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Info className={iconClass} />
+                </InputAdornment>
+              ),
+            }}
+          />
         </div>
       </div>
     </fieldset>

--- a/src/components/masters/EquipmentCategoryForm.tsx
+++ b/src/components/masters/EquipmentCategoryForm.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { EquipmentCategory, EquipmentCategoryFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, Tag, Info } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface EquipmentCategoryFormProps {
   category?: EquipmentCategory | null;
@@ -98,8 +100,16 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
           <div>
             <label htmlFor="category_name" className={labelClass}>Category Name <span className="text-red-500">*</span></label>
             <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><Tag className={iconClass} /></div>
-                <input type="text" name="category_name" id="category_name" value={formData.category_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
+                <OutlinedTextField
+                  type="text"
+                  name="category_name"
+                  id="category_name"
+                  value={formData.category_name}
+                  onChange={handleChange}
+                  className={inputClass}
+                  InputProps={{ startAdornment: <InputAdornment position="start"><Tag className={iconClass} /></InputAdornment> }}
+                  required
+                />
             </div>
             {formErrors.category_name && <p className="text-xs text-red-500 mt-1">{formErrors.category_name}</p>}
           </div>
@@ -107,8 +117,16 @@ const EquipmentCategoryForm: React.FC<EquipmentCategoryFormProps> = ({ category,
           <div>
             <label htmlFor="description" className={labelClass}>Description</label>
             <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className={`${inputClass} pl-10`}></textarea>
+                <OutlinedTextField
+                  name="description"
+                  id="description"
+                  value={formData.description || ''}
+                  onChange={handleChange}
+                  multiline
+                  rows={4}
+                  className={inputClass}
+                  InputProps={{ startAdornment: <InputAdornment position="start"><Info className={iconClass} /></InputAdornment> }}
+                />
             </div>
           </div>
 

--- a/src/components/masters/PaymentPlanForm.tsx
+++ b/src/components/masters/PaymentPlanForm.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { PaymentPlan, PaymentPlanFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, ListChecks, Info, CalendarClock } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface PaymentPlanFormProps {
   plan?: PaymentPlan | null;
@@ -110,8 +112,16 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
           <div>
             <label htmlFor="plan_name" className={labelClass}>Plan Name <span className="text-red-500">*</span></label>
              <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><ListChecks className={iconClass} /></div>
-                <input type="text" name="plan_name" id="plan_name" value={formData.plan_name} onChange={handleChange} className={`${inputClass} pl-10`} required />
+                <OutlinedTextField
+                  type="text"
+                  name="plan_name"
+                  id="plan_name"
+                  value={formData.plan_name}
+                  onChange={handleChange}
+                  className={inputClass}
+                  InputProps={{ startAdornment: <InputAdornment position="start"><ListChecks className={iconClass} /></InputAdornment> }}
+                  required
+                />
             </div>
             {formErrors.plan_name && <p className="text-xs text-red-500 mt-1">{formErrors.plan_name}</p>}
           </div>
@@ -119,8 +129,16 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
           <div>
             <label htmlFor="frequency_in_days" className={labelClass}>Frequency (in days)</label>
             <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><CalendarClock className={iconClass} /></div>
-                <input type="number" name="frequency_in_days" id="frequency_in_days" value={formData.frequency_in_days || ''} onChange={handleChange} className={`${inputClass} pl-10`} min="1" />
+                <OutlinedTextField
+                  type="number"
+                  name="frequency_in_days"
+                  id="frequency_in_days"
+                  value={formData.frequency_in_days || ''}
+                  onChange={handleChange}
+                  className={inputClass}
+                  inputProps={{ min: '1' }}
+                  InputProps={{ startAdornment: <InputAdornment position="start"><CalendarClock className={iconClass} /></InputAdornment> }}
+                />
             </div>
             {formErrors.frequency_in_days && <p className="text-xs text-red-500 mt-1">{formErrors.frequency_in_days}</p>}
           </div>
@@ -128,8 +146,16 @@ const PaymentPlanForm: React.FC<PaymentPlanFormProps> = ({ plan, onSave, onCance
           <div>
             <label htmlFor="description" className={labelClass}>Description</label>
             <div className="mt-1 relative rounded-md shadow-sm">
-                <div className="absolute inset-y-0 left-0 top-2 pl-3 flex items-start pointer-events-none"><Info className={iconClass} /></div>
-                <textarea name="description" id="description" value={formData.description || ''} onChange={handleChange} rows={4} className={`${inputClass} pl-10`}></textarea>
+                <OutlinedTextField
+                  name="description"
+                  id="description"
+                  value={formData.description || ''}
+                  onChange={handleChange}
+                  multiline
+                  rows={4}
+                  className={inputClass}
+                  InputProps={{ startAdornment: <InputAdornment position="start"><Info className={iconClass} /></InputAdornment> }}
+                />
             </div>
           </div>
 

--- a/src/components/payments/PaymentForm.tsx
+++ b/src/components/payments/PaymentForm.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { Payment, PaymentFormData } from '../../types';
 import { useCrud } from '../../context/CrudContext';
 import { Save, X, Loader2, CalendarCheck2, IndianRupee } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import AutocompleteField from '../ui/AutocompleteField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 import DatePickerField from "../ui/DatePickerField";
 import dayjs from 'dayjs';
@@ -117,7 +120,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
     onSave();
   };
 
-  const inputClass = 'mt-1 block w-full border-light-gray-300 rounded-md shadow-sm focus:ring-brand-blue focus:border-brand-blue sm:text-sm';
+  const inputClass = 'mt-1 block w-full';
 
   return (
     <div className="bg-white p-6 rounded-md shadow">
@@ -126,7 +129,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
           <label htmlFor="rental_id" className="block text-sm font-medium text-dark-text mb-1">
             Rental ID
           </label>
-          <input
+          <OutlinedTextField
             type="text"
             id="rental_id"
             name="rental_id"
@@ -178,39 +181,40 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
           <label htmlFor="payment_amount" className="block text-sm font-medium text-dark-text mb-1">
             Amount
           </label>
-          <div className="relative">
-            <span className="absolute left-3 top-2.5 text-gray-500">
-              <IndianRupee size={16} />
-            </span>
-            <input
-              type="number"
-              id="payment_amount"
-              name="payment_amount"
-              value={formData.payment_amount || ''}
-              onChange={handleChange}
-              className={`${inputClass} pl-8`}
-            />
-          </div>
+          <OutlinedTextField
+            type="number"
+            id="payment_amount"
+            name="payment_amount"
+            value={formData.payment_amount || ''}
+            onChange={handleChange}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <IndianRupee size={16} />
+                </InputAdornment>
+              ),
+            }}
+            className={inputClass}
+          />
         </div>
         <div>
           <label htmlFor="payment_mode_select" className="block text-sm font-medium text-dark-text mb-1">
             Mode
           </label>
           <div className="flex items-center space-x-2">
-            <select
-              id="payment_mode_select"
-              value={modeSelect}
-              onChange={handleModeSelectChange}
-              className={inputClass}
-            >
-              <option value="">Select</option>
-              {KNOWN_MODES.map(m => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-              <option value="Others">Others</option>
-            </select>
+            <div className="flex-1">
+              <AutocompleteField
+                id="payment_mode_select"
+                name="payment_mode_select"
+                value={modeSelect}
+                onChange={handleModeSelectChange as React.ChangeEventHandler<HTMLInputElement>}
+                options={[
+                  { label: 'Select', value: '' },
+                  ...KNOWN_MODES.map(m => ({ label: m, value: m })),
+                  { label: 'Others', value: 'Others' },
+                ]}
+              />
+            </div>
             <button
               type="button"
               onClick={() => {
@@ -230,7 +234,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
             <label htmlFor="payment_mode_other" className="block text-sm font-medium text-dark-text mb-1">
               Specify Mode
             </label>
-            <input
+            <OutlinedTextField
               type="text"
               id="payment_mode_other"
               value={otherMode}
@@ -243,7 +247,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
           <label htmlFor="payment_reference" className="block text-sm font-medium text-dark-text mb-1">
             Reference
           </label>
-          <input
+          <OutlinedTextField
             type="text"
             id="payment_reference"
             name="payment_reference"
@@ -256,12 +260,13 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ payment, onSave, onCancel }) 
           <label htmlFor="notes" className="block text-sm font-medium text-dark-text mb-1">
             Notes
           </label>
-          <textarea
+          <OutlinedTextField
             id="notes"
             name="notes"
             value={formData.notes || ''}
             onChange={handleChange}
             className={inputClass}
+            multiline
             rows={3}
           />
         </div>

--- a/src/components/rentals/RentalCustomerSection.tsx
+++ b/src/components/rentals/RentalCustomerSection.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Customer as CustomerType } from '../../types';
 import { Loader2, User } from 'lucide-react';
+import AutocompleteField from '../ui/AutocompleteField';
 
 interface Props {
   customerId: string;
   customers: CustomerType[];
   loadingCustomers: boolean;
-  handleChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   inputClass: string;
   labelClass: string;
@@ -39,24 +40,18 @@ const RentalCustomerSection: React.FC<Props> = ({
             <User className={iconClass} />
           )}
         </div>
-        <select
-          name="customer_id"
-          id="customer_id"
-          value={customerId}
-          onChange={handleChange}
-          className={`${inputClass} pl-10`}
-          required
-          disabled={loadingCustomers}
-        >
-          <option value="">
-            {loadingCustomers ? 'Loading...' : 'Select Customer'}
-          </option>
-          {customers.map((c) => (
-            <option key={c.customer_id} value={c.customer_id}>
-              {c.full_name}
-            </option>
-          ))}
-        </select>
+        <div className="pl-10">
+          <AutocompleteField
+            name="customer_id"
+            id="customer_id"
+            value={customerId}
+            onChange={handleChange}
+            options={customers.map((c) => ({ label: c.full_name, value: String(c.customer_id) }))}
+            loading={loadingCustomers}
+            disabled={loadingCustomers}
+            placeholder={loadingCustomers ? 'Loading...' : 'Select Customer'}
+          />
+        </div>
       </div>
       {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
     </div>

--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { RentalItemFormData, Equipment as EquipmentType } from '../../types';
 import { Trash2, PackagePlus } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import AutocompleteField from '../ui/AutocompleteField';
+import InputAdornment from '@mui/material/InputAdornment';
 import { formatCurrency } from '../../utils/formatting';
 
 interface Props {
@@ -45,40 +48,45 @@ const RentalItemsSection: React.FC<Props> = ({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
             <div>
               <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
-              <select
+              <AutocompleteField
                 id={`item_equipment_${index}`}
+                name={`item_equipment_${index}`}
                 value={item.equipment_id}
                 onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
-                className={`${inputClass} text-xs py-1.5`}
-                disabled={loadingEquipment}
-              >
-                <option value="">{loadingEquipment ? 'Loading...' : 'Select Equipment'}</option>
-                {availableEquipment
+                options={availableEquipment
                   .filter(eq =>
                     eq.status === 'Available' ||
                     items.some(it => it.equipment_id === String(eq.equipment_id))
                   )
-                  .map(eq => (
-                    <option key={eq.equipment_id} value={String(eq.equipment_id)}>
-                      {eq.equipment_name} (SN: {eq.serial_number || 'N/A'}) - Rate: {formatCurrency(eq.rental_rate)}
-                    </option>
-                  ))}
-              </select>
+                  .map(eq => ({
+                    value: String(eq.equipment_id),
+                    label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
+                  }))}
+                loading={loadingEquipment}
+                disabled={loadingEquipment}
+                placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
+              />
               {formErrors[`rental_items.${index}.equipment_id`] && (
                 <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>
               )}
             </div>
             <div>
               <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
-              <input
+              <OutlinedTextField
                 type="number"
                 id={`item_rate_${index}`}
                 value={item.unit_rental_rate}
                 onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
-                className={`${inputClass} text-xs py-1.5`}
-                step="0.01"
-                min="0"
+                className={`${inputClass} text-xs`}
+                inputProps={{ step: '0.01', min: '0' }}
                 placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      ₹
+                    </InputAdornment>
+                  ),
+                }}
               />
               {formErrors[`rental_items.${index}.unit_rental_rate`] && (
                 <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>

--- a/src/components/rentals/RentalShippingBilling.tsx
+++ b/src/components/rentals/RentalShippingBilling.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { RentalTransactionFormData } from '../../types';
 import { Loader2 } from 'lucide-react';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import AutocompleteField from '../ui/AutocompleteField';
+import InputAdornment from '@mui/material/InputAdornment';
 
 interface Props {
   data: Pick<
@@ -20,7 +23,7 @@ interface Props {
   >;
   errors: Record<string, string>;
   handleChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
   shippingPincodeDetailsLoading: boolean;
   shippingPincodeError: string | null;
@@ -75,33 +78,34 @@ const RentalShippingBilling: React.FC<Props> = ({
       <div className="space-y-4">
         <div>
           <label htmlFor="shipping_address" className={labelClass}>Shipping Address</label>
-          <textarea
+          <OutlinedTextField
             id="shipping_address"
             name="shipping_address"
             value={data.shipping_address || ''}
             onChange={handleChange}
+            multiline
             rows={2}
             className={inputClass}
           />
         </div>
         <div>
           <label htmlFor="shipping_pincode" className={labelClass}>Shipping Pincode</label>
-          <div className="relative">
-            <input
-              type="text"
-              id="shipping_pincode"
-              name="shipping_pincode"
-              value={data.shipping_pincode || ''}
-              onChange={handleChange}
-              className={inputClass}
-              maxLength={6}
-            />
-            {shippingPincodeDetailsLoading && (
-              <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-              </div>
-            )}
-          </div>
+          <OutlinedTextField
+            type="text"
+            id="shipping_pincode"
+            name="shipping_pincode"
+            value={data.shipping_pincode || ''}
+            onChange={handleChange}
+            className={inputClass}
+            inputProps={{ maxLength: 6 }}
+            InputProps={{
+              endAdornment: shippingPincodeDetailsLoading ? (
+                <InputAdornment position="end">
+                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                </InputAdornment>
+              ) : undefined,
+            }}
+          />
           {errors.shipping_pincode && (
             <p className="text-xs text-red-500 mt-1">{errors.shipping_pincode}</p>
           )}
@@ -112,29 +116,23 @@ const RentalShippingBilling: React.FC<Props> = ({
         <div>
           <label htmlFor="shipping_area" className={labelClass}>Shipping Area</label>
           {shippingIsAreaSelect ? (
-            <select
+            <AutocompleteField
               id="shipping_area"
               name="shipping_area"
               value={data.shipping_area || ''}
               onChange={handleChange}
-              className={inputClass}
-            >
-              <option value="">Select Area</option>
-              {shippingAreaOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+              options={shippingAreaOptions}
+              placeholder="Select Area"
+            />
           ) : (
-            <input
+            <OutlinedTextField
               type="text"
               id="shipping_area"
               name="shipping_area"
               value={data.shipping_area || ''}
               onChange={handleChange}
               className={inputClass}
-              readOnly={shippingAreaOptions.length > 0 && !shippingIsAreaSelect}
+              InputProps={{ readOnly: shippingAreaOptions.length > 0 && !shippingIsAreaSelect }}
             />
           )}
           {errors.shipping_area && (
@@ -143,59 +141,60 @@ const RentalShippingBilling: React.FC<Props> = ({
         </div>
         <div>
           <label htmlFor="shipping_city" className={labelClass}>Shipping City</label>
-          <input
+          <OutlinedTextField
             type="text"
             id="shipping_city"
             name="shipping_city"
             value={data.shipping_city || ''}
             onChange={handleChange}
             className={inputClass}
-            readOnly
+            InputProps={{ readOnly: true }}
           />
         </div>
         <div>
           <label htmlFor="shipping_state" className={labelClass}>Shipping State</label>
-          <input
+          <OutlinedTextField
             type="text"
             id="shipping_state"
             name="shipping_state"
             value={data.shipping_state || ''}
             onChange={handleChange}
             className={inputClass}
-            readOnly
+            InputProps={{ readOnly: true }}
           />
         </div>
       </div>
       <div className="space-y-4">
         <div>
           <label htmlFor="billing_address" className={labelClass}>Billing Address</label>
-          <textarea
+          <OutlinedTextField
             id="billing_address"
             name="billing_address"
             value={data.billing_address || ''}
             onChange={handleChange}
+            multiline
             rows={2}
             className={inputClass}
           />
         </div>
         <div>
           <label htmlFor="billing_pincode" className={labelClass}>Billing Pincode</label>
-          <div className="relative">
-            <input
-              type="text"
-              id="billing_pincode"
-              name="billing_pincode"
-              value={data.billing_pincode || ''}
-              onChange={handleChange}
-              className={inputClass}
-              maxLength={6}
-            />
-            {billingPincodeDetailsLoading && (
-              <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-              </div>
-            )}
-          </div>
+          <OutlinedTextField
+            type="text"
+            id="billing_pincode"
+            name="billing_pincode"
+            value={data.billing_pincode || ''}
+            onChange={handleChange}
+            className={inputClass}
+            inputProps={{ maxLength: 6 }}
+            InputProps={{
+              endAdornment: billingPincodeDetailsLoading ? (
+                <InputAdornment position="end">
+                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                </InputAdornment>
+              ) : undefined,
+            }}
+          />
           {errors.billing_pincode && (
             <p className="text-xs text-red-500 mt-1">{errors.billing_pincode}</p>
           )}
@@ -206,29 +205,23 @@ const RentalShippingBilling: React.FC<Props> = ({
         <div>
           <label htmlFor="billing_area" className={labelClass}>Billing Area</label>
           {billingIsAreaSelect ? (
-            <select
+            <AutocompleteField
               id="billing_area"
               name="billing_area"
               value={data.billing_area || ''}
               onChange={handleChange}
-              className={inputClass}
-            >
-              <option value="">Select Area</option>
-              {billingAreaOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+              options={billingAreaOptions}
+              placeholder="Select Area"
+            />
           ) : (
-            <input
+            <OutlinedTextField
               type="text"
               id="billing_area"
               name="billing_area"
               value={data.billing_area || ''}
               onChange={handleChange}
               className={inputClass}
-              readOnly={billingAreaOptions.length > 0 && !billingIsAreaSelect}
+              InputProps={{ readOnly: billingAreaOptions.length > 0 && !billingIsAreaSelect }}
             />
           )}
           {errors.billing_area && (
@@ -237,26 +230,26 @@ const RentalShippingBilling: React.FC<Props> = ({
         </div>
         <div>
           <label htmlFor="billing_city" className={labelClass}>Billing City</label>
-          <input
+          <OutlinedTextField
             type="text"
             id="billing_city"
             name="billing_city"
             value={data.billing_city || ''}
             onChange={handleChange}
             className={inputClass}
-            readOnly
+            InputProps={{ readOnly: true }}
           />
         </div>
         <div>
           <label htmlFor="billing_state" className={labelClass}>Billing State</label>
-          <input
+          <OutlinedTextField
             type="text"
             id="billing_state"
             name="billing_state"
             value={data.billing_state || ''}
             onChange={handleChange}
             className={inputClass}
-            readOnly
+            InputProps={{ readOnly: true }}
           />
         </div>
       </div>
@@ -266,7 +259,7 @@ const RentalShippingBilling: React.FC<Props> = ({
         <label htmlFor="mobile_number" className={labelClass}>
           Mobile Number
         </label>
-        <input
+        <OutlinedTextField
           type="text"
           id="mobile_number"
           name="mobile_number"
@@ -279,7 +272,7 @@ const RentalShippingBilling: React.FC<Props> = ({
         <label htmlFor="email" className={labelClass}>
           Email
         </label>
-        <input
+        <OutlinedTextField
           type="email"
           id="email"
           name="email"

--- a/src/components/rentals/RentalStatusDates.tsx
+++ b/src/components/rentals/RentalStatusDates.tsx
@@ -3,11 +3,12 @@ import { CalendarDays, ChevronDown } from 'lucide-react';
 import { RentalTransactionFormData } from '../../types';
 
 import DatePickerField from "../ui/DatePickerField";
+import AutocompleteField from '../ui/AutocompleteField';
 interface Props {
   data: Pick<RentalTransactionFormData, 'rental_date' | 'expected_return_date' | 'status'>;
   numberOfDays: number;
   errors: Partial<Record<'rental_date' | 'expected_return_date' | 'status', string>>;
-  handleChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   inputClass: string;
   labelClass: string;
   iconClass: string;
@@ -74,20 +75,16 @@ const RentalStatusDates: React.FC<Props> = ({
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <ChevronDown className={iconClass} />
         </div>
-        <select
-          name="status"
-          id="status"
-          value={data.status || ''}
-          onChange={handleChange}
-          className={`${inputClass} pl-10`}
-          required
-        >
-          {statusOptions.map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
+        <div className="pl-10">
+          <AutocompleteField
+            name="status"
+            id="status"
+            value={data.status || ''}
+            onChange={handleChange}
+            options={statusOptions.map((s) => ({ label: s, value: s }))}
+            placeholder="Select status"
+          />
+        </div>
       </div>
       {errors.status && <p className="text-xs text-red-500 mt-1">{errors.status}</p>}
     </div>

--- a/src/components/ui/AutocompleteField.tsx
+++ b/src/components/ui/AutocompleteField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
-import TextField from '@mui/material/TextField';
+import OutlinedTextField from './OutlinedTextField';
 import CircularProgress from '@mui/material/CircularProgress';
 
 export interface AutocompleteOption {
@@ -51,7 +51,7 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
       loading={loading}
       disabled={disabled}
       renderInput={(params) => (
-        <TextField
+        <OutlinedTextField
           {...params}
           name={name}
           id={id}

--- a/src/components/ui/SearchBox.tsx
+++ b/src/components/ui/SearchBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import TextField from '@mui/material/TextField';
+import OutlinedTextField from './OutlinedTextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import SearchIcon from '@mui/icons-material/Search';
 
@@ -15,9 +15,8 @@ const SearchBox: React.FC<SearchBoxProps> = ({
   placeholder = 'Search customers...'
 }) => {
   return (
-    <TextField
+    <OutlinedTextField
       fullWidth
-      variant="outlined"
       placeholder={placeholder}
       value={value}
       onChange={(e) => onChange(e.target.value)}


### PR DESCRIPTION
## Summary
- wrap payment form fields with `OutlinedTextField` and add autocomplete for mode
- update rental transaction components to use `OutlinedTextField` and `AutocompleteField`
- convert maintenance forms and master data forms to outlined fields with adornments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68414eff1ff48321bd2af45a1b94036c