### PR TITLE
Implement UI improvements for rental pages

### DIFF
--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -16,6 +16,7 @@ interface Props {
   addItem: () => void;
   inputClass: string;
   labelClass: string;
+  isEditing?: boolean;
 }
 
 const RentalItemsSection: React.FC<Props> = ({
@@ -28,74 +29,148 @@ const RentalItemsSection: React.FC<Props> = ({
   addItem,
   inputClass,
   labelClass,
+  isEditing = false,
 }) => (
   <fieldset>
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Rental Items</legend>
     {formErrors.rental_items && typeof formErrors.rental_items !== 'object' && (
       <p className="text-xs text-red-500 mb-2">{formErrors.rental_items}</p>
     )}
-    <div className="space-y-4 max-h-60 overflow-y-auto pr-2">
-      {items.map((item, index) => (
-        <div key={item.temp_id} className="p-4 border border-light-gray-200 rounded-md space-y-3 bg-light-gray-50 relative">
-          <button
-            type="button"
-            onClick={() => removeItem(index)}
-            className="absolute top-2 right-2 p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
-            title="Remove Item"
-          >
-            <Trash2 size={16} />
-          </button>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
-            <div>
-              <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
-              <AutocompleteField
-                id={`item_equipment_${index}`}
-                name={`item_equipment_${index}`}
-                value={item.equipment_id}
-                onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
-                options={availableEquipment
-                  .filter(eq =>
-                    eq.status === 'Available' ||
-                    items.some(it => it.equipment_id === String(eq.equipment_id))
-                  )
-                  .map(eq => ({
-                    value: String(eq.equipment_id),
-                    label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
-                  }))}
-                loading={loadingEquipment}
-                disabled={loadingEquipment}
-                placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
-              />
-              {formErrors[`rental_items.${index}.equipment_id`] && (
-                <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>
-              )}
-            </div>
-            <div>
-              <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
-              <OutlinedTextField
-                type="number"
-                id={`item_rate_${index}`}
-                value={item.unit_rental_rate}
-                onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
-                className={`${inputClass} text-xs`}
-                inputProps={{ step: '0.01', min: '0' }}
-                placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      ₹
-                    </InputAdornment>
-                  ),
-                }}
-              />
-              {formErrors[`rental_items.${index}.unit_rental_rate`] && (
-                <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>
-              )}
+    {isEditing ? (
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Equipment</th>
+              <th className="p-2">Unit Rate (₹/day)</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, index) => (
+              <tr key={item.temp_id} className="border-b last:border-b-0">
+                <td className="p-2">
+                  <AutocompleteField
+                    id={`item_equipment_${index}`}
+                    name={`item_equipment_${index}`}
+                    value={item.equipment_id}
+                    onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
+                    options={availableEquipment
+                      .filter(eq =>
+                        eq.status === 'Available' ||
+                        items.some(it => it.equipment_id === String(eq.equipment_id))
+                      )
+                      .map(eq => ({
+                        value: String(eq.equipment_id),
+                        label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
+                      }))}
+                    loading={loadingEquipment}
+                    disabled={loadingEquipment}
+                    placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
+                    className="w-full"
+                  />
+                  {formErrors[`rental_items.${index}.equipment_id`] && (
+                    <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>
+                  )}
+                </td>
+                <td className="p-2">
+                  <OutlinedTextField
+                    type="number"
+                    id={`item_rate_${index}`}
+                    value={item.unit_rental_rate}
+                    onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
+                    className={`${inputClass} text-xs`}
+                    inputProps={{ step: '0.01', min: '0' }}
+                    placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
+                    InputProps={{
+                      startAdornment: (
+                        <InputAdornment position="start">₹</InputAdornment>
+                      ),
+                    }}
+                  />
+                  {formErrors[`rental_items.${index}.unit_rental_rate`] && (
+                    <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>
+                  )}
+                </td>
+                <td className="p-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => removeItem(index)}
+                    className="p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
+                    title="Remove Item"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    ) : (
+      <div className="space-y-4 max-h-60 overflow-y-auto pr-2">
+        {items.map((item, index) => (
+          <div key={item.temp_id} className="p-4 border border-light-gray-200 rounded-md space-y-3 bg-light-gray-50 relative">
+            <button
+              type="button"
+              onClick={() => removeItem(index)}
+              className="absolute top-2 right-2 p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
+              title="Remove Item"
+            >
+              <Trash2 size={16} />
+            </button>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
+              <div>
+                <label htmlFor={`item_equipment_${index}`} className={`${labelClass} text-xs`}>Equipment <span className="text-red-500">*</span></label>
+                <AutocompleteField
+                  id={`item_equipment_${index}`}
+                  name={`item_equipment_${index}`}
+                  value={item.equipment_id}
+                  onChange={(e) => handleItemChange(index, 'equipment_id', e.target.value)}
+                  options={availableEquipment
+                    .filter(eq =>
+                      eq.status === 'Available' ||
+                      items.some(it => it.equipment_id === String(eq.equipment_id))
+                    )
+                    .map(eq => ({
+                      value: String(eq.equipment_id),
+                      label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
+                    }))}
+                  loading={loadingEquipment}
+                  disabled={loadingEquipment}
+                  placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
+                />
+                {formErrors[`rental_items.${index}.equipment_id`] && (
+                  <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.equipment_id`]}</p>
+                )}
+              </div>
+              <div>
+                <label htmlFor={`item_rate_${index}`} className={`${labelClass} text-xs`}>Unit Rate (₹/day) <span className="text-red-500">*</span></label>
+                <OutlinedTextField
+                  type="number"
+                  id={`item_rate_${index}`}
+                  value={item.unit_rental_rate}
+                  onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
+                  className={`${inputClass} text-xs`}
+                  inputProps={{ step: '0.01', min: '0' }}
+                  placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        ₹
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                {formErrors[`rental_items.${index}.unit_rental_rate`] && (
+                  <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    )}
     <button
       type="button"
       onClick={addItem}

--- a/src/components/rentals/RentalShippingBilling.tsx
+++ b/src/components/rentals/RentalShippingBilling.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RentalTransactionFormData } from '../../types';
 import { Loader2 } from 'lucide-react';
+import Button from '@mui/material/Button';
 import OutlinedTextField from '../ui/OutlinedTextField';
 import AutocompleteField from '../ui/AutocompleteField';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -59,20 +60,10 @@ const RentalShippingBilling: React.FC<Props> = ({
   <fieldset className="space-y-6">
     <legend className="text-lg font-medium text-dark-text mb-2">Shipping &amp; Billing</legend>
     <div className="flex gap-4 text-xs">
-      <button
-        type="button"
-        onClick={copyShippingToBilling}
-        className="text-brand-blue underline"
-      >
-        Copy Shipping to Billing
-      </button>
-      <button
-        type="button"
-        onClick={copyBillingToShipping}
-        className="text-brand-blue underline"
-      >
-        Copy Billing to Shipping
-      </button>
+      <Button variant="outlined" size="small" onClick={copyShippingToBilling}
+        >Copy Shipping to Billing</Button>
+      <Button variant="outlined" size="small" onClick={copyBillingToShipping}
+        >Copy Billing to Shipping</Button>
     </div>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div className="space-y-4">
@@ -115,53 +106,44 @@ const RentalShippingBilling: React.FC<Props> = ({
         </div>
         <div>
           <label htmlFor="shipping_area" className={labelClass}>Shipping Area</label>
-          {shippingIsAreaSelect ? (
-            <AutocompleteField
-              id="shipping_area"
-              name="shipping_area"
-              value={data.shipping_area || ''}
-              onChange={handleChange}
-              options={shippingAreaOptions}
-              placeholder="Select Area"
-            />
-          ) : (
-            <OutlinedTextField
-              type="text"
-              id="shipping_area"
-              name="shipping_area"
-              value={data.shipping_area || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: shippingAreaOptions.length > 0 && !shippingIsAreaSelect }}
-            />
-          )}
+          <AutocompleteField
+            id="shipping_area"
+            name="shipping_area"
+            value={data.shipping_area || ''}
+            onChange={handleChange}
+            options={shippingAreaOptions}
+            placeholder="Select Area"
+            freeSolo
+          />
           {errors.shipping_area && (
             <p className="text-xs text-red-500 mt-1">{errors.shipping_area}</p>
           )}
         </div>
-        <div>
-          <label htmlFor="shipping_city" className={labelClass}>Shipping City</label>
-          <OutlinedTextField
-            type="text"
-            id="shipping_city"
-            name="shipping_city"
-            value={data.shipping_city || ''}
-            onChange={handleChange}
-            className={inputClass}
-            InputProps={{ readOnly: true }}
-          />
-        </div>
-        <div>
-          <label htmlFor="shipping_state" className={labelClass}>Shipping State</label>
-          <OutlinedTextField
-            type="text"
-            id="shipping_state"
-            name="shipping_state"
-            value={data.shipping_state || ''}
-            onChange={handleChange}
-            className={inputClass}
-            InputProps={{ readOnly: true }}
-          />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="shipping_city" className={labelClass}>Shipping City</label>
+            <OutlinedTextField
+              type="text"
+              id="shipping_city"
+              name="shipping_city"
+              value={data.shipping_city || ''}
+              onChange={handleChange}
+              className={inputClass}
+              InputProps={{ readOnly: true }}
+            />
+          </div>
+          <div>
+            <label htmlFor="shipping_state" className={labelClass}>Shipping State</label>
+            <OutlinedTextField
+              type="text"
+              id="shipping_state"
+              name="shipping_state"
+              value={data.shipping_state || ''}
+              onChange={handleChange}
+              className={inputClass}
+              InputProps={{ readOnly: true }}
+            />
+          </div>
         </div>
       </div>
       <div className="space-y-4">
@@ -204,53 +186,44 @@ const RentalShippingBilling: React.FC<Props> = ({
         </div>
         <div>
           <label htmlFor="billing_area" className={labelClass}>Billing Area</label>
-          {billingIsAreaSelect ? (
-            <AutocompleteField
-              id="billing_area"
-              name="billing_area"
-              value={data.billing_area || ''}
-              onChange={handleChange}
-              options={billingAreaOptions}
-              placeholder="Select Area"
-            />
-          ) : (
-            <OutlinedTextField
-              type="text"
-              id="billing_area"
-              name="billing_area"
-              value={data.billing_area || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: billingAreaOptions.length > 0 && !billingIsAreaSelect }}
-            />
-          )}
+          <AutocompleteField
+            id="billing_area"
+            name="billing_area"
+            value={data.billing_area || ''}
+            onChange={handleChange}
+            options={billingAreaOptions}
+            placeholder="Select Area"
+            freeSolo
+          />
           {errors.billing_area && (
             <p className="text-xs text-red-500 mt-1">{errors.billing_area}</p>
           )}
         </div>
-        <div>
-          <label htmlFor="billing_city" className={labelClass}>Billing City</label>
-          <OutlinedTextField
-            type="text"
-            id="billing_city"
-            name="billing_city"
-            value={data.billing_city || ''}
-            onChange={handleChange}
-            className={inputClass}
-            InputProps={{ readOnly: true }}
-          />
-        </div>
-        <div>
-          <label htmlFor="billing_state" className={labelClass}>Billing State</label>
-          <OutlinedTextField
-            type="text"
-            id="billing_state"
-            name="billing_state"
-            value={data.billing_state || ''}
-            onChange={handleChange}
-            className={inputClass}
-            InputProps={{ readOnly: true }}
-          />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="billing_city" className={labelClass}>Billing City</label>
+            <OutlinedTextField
+              type="text"
+              id="billing_city"
+              name="billing_city"
+              value={data.billing_city || ''}
+              onChange={handleChange}
+              className={inputClass}
+              InputProps={{ readOnly: true }}
+            />
+          </div>
+          <div>
+            <label htmlFor="billing_state" className={labelClass}>Billing State</label>
+            <OutlinedTextField
+              type="text"
+              id="billing_state"
+              name="billing_state"
+              value={data.billing_state || ''}
+              onChange={handleChange}
+              className={inputClass}
+              InputProps={{ readOnly: true }}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -21,6 +21,8 @@ import {
   ListChecks,
   Info,
 } from 'lucide-react';
+import Button from '@mui/material/Button';
+import AutocompleteField from '../ui/AutocompleteField';
 import RentalItemsSection from './RentalItemsSection';
 import RentalCustomerSection from './RentalCustomerSection';
 import RentalStatusDates from './RentalStatusDates';
@@ -531,13 +533,14 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
           />
 
           <div>
-            <button
-              type="button"
+            <Button
+              variant="outlined"
+              size="small"
               onClick={() => setShowAddressSection(s => !s)}
-              className="text-brand-blue underline mb-2 text-sm"
+              className="mb-2"
             >
               {showAddressSection ? 'Hide Shipping & Billing' : 'Show Shipping & Billing'}
-            </button>
+            </Button>
             {showAddressSection && (
               <RentalShippingBilling
                 data={{
@@ -597,6 +600,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             addItem={addItem}
             inputClass={inputClass}
             labelClass={labelClass}
+            isEditing={isEditing}
           />
 
           <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
@@ -604,21 +608,30 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             <div>
               <label htmlFor="payment_term" className={labelClass}>Payment Term</label>
               <div className="mt-1 relative rounded-md shadow-sm">
-                 <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    {loadingPaymentPlans ? <Loader2 className={`${iconClass} animate-spin`} /> : <ListChecks className={iconClass} />}
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  {loadingPaymentPlans ? <Loader2 className={`${iconClass} animate-spin`} /> : <ListChecks className={iconClass} />}
                 </div>
-                <select name="payment_term" id="payment_term" value={formData.payment_term || ''} onChange={handleChange} className={`${inputClass} pl-10`} disabled={loadingPaymentPlans}>
-                  <option value="">{loadingPaymentPlans ? "Loading..." : "Select Payment Term"}</option>
-                  {paymentPlans.map((pt: PaymentPlanType) => <option key={pt.plan_id} value={pt.plan_name}>{pt.plan_name}</option>)}
-                </select>
+                <div className="pl-10">
+                  <AutocompleteField
+                    name="payment_term"
+                    id="payment_term"
+                    value={formData.payment_term || ''}
+                    onChange={handleChange}
+                    options={paymentPlans.map(pt => ({ label: pt.plan_name, value: pt.plan_name }))}
+                    loading={loadingPaymentPlans}
+                    disabled={loadingPaymentPlans}
+                    placeholder={loadingPaymentPlans ? 'Loading...' : 'Select Payment Term'}
+                    freeSolo
+                  />
+                </div>
               </div>
             </div>
 
-            <div className="md:col-span-2">
-                <label className={labelClass}>Calculated Total Rental Amount</label>
-                <p className="mt-1 px-3 py-2 bg-light-gray-100 border border-light-gray-300 rounded-md text-dark-text/80 sm:text-sm flex items-center font-semibold text-green-700">
-                   <IndianRupee size={18} className="mr-2"/> {formatCurrency(calculatedTotalAmount)}
-                </p>
+            <div>
+              <label className={labelClass}>Calculated Total Rental Amount</label>
+              <p className="mt-1 px-3 py-2 bg-light-gray-100 border border-light-gray-300 rounded-md text-dark-text/80 sm:text-sm flex items-center font-semibold text-green-700">
+                 <IndianRupee size={18} className="mr-2"/> {formatCurrency(calculatedTotalAmount)}
+              </p>
             </div>
 
             <div className="md:col-span-2">

--- a/src/components/ui/AutocompleteField.tsx
+++ b/src/components/ui/AutocompleteField.tsx
@@ -17,6 +17,7 @@ interface AutocompleteFieldProps {
   loading?: boolean;
   disabled?: boolean;
   placeholder?: string;
+  freeSolo?: boolean;
 }
 
 const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
@@ -28,6 +29,7 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
   loading = false,
   disabled = false,
   placeholder,
+  freeSolo = false,
 }) => {
   const selectedOption =
     options.find((opt) => String(opt.value) === String(value)) || null;
@@ -44,6 +46,7 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
 
   return (
     <Autocomplete
+      freeSolo={freeSolo}
       options={options}
       getOptionLabel={(option) => option.label}
       value={selectedOption}


### PR DESCRIPTION
## Summary
- support `freeSolo` option in `AutocompleteField`
- swap shipping & billing copy actions to MUI outlined buttons
- align shipping/billing city & state fields
- add button to toggle address section visibility
- use `AutocompleteField` for payment term
- place payment term and total amount on the same row
- display rental items as a grid during editing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684167d308788321886dc183a301cfbb