### PR TITLE
Align pincode and area on rental forms

### DIFF
--- a/src/components/CustomerForm.tsx
+++ b/src/components/CustomerForm.tsx
@@ -8,7 +8,7 @@ import usePincodeLookup from '../utils/usePincodeLookup';
 
 interface CustomerFormProps {
   customer?: Customer | null; // For editing, null/undefined for creating
-  onSave: () => void;
+  onSave: (newCustomerId?: number | null) => void;
   onCancel: () => void;
 }
 
@@ -130,12 +130,15 @@ const CustomerForm: React.FC<CustomerFormProps> = ({ customer, onSave, onCancel 
         }
       }
 
+      let newId: number | null = null;
       if (customer && customer.customer_id) {
         await updateItem('customers', customer.customer_id, apiData);
+        newId = Number(customer.customer_id);
       } else {
-        await createItem('customers', apiData);
+        const res = await createItem('customers', apiData);
+        newId = res?.data?.customer_id ?? res?.data?.insertId ?? null;
       }
-      onSave();
+      onSave(newId);
     } catch (err) {
       console.error('Failed to save customer:', err);
     }

--- a/src/components/dashboard/RentalsTab.tsx
+++ b/src/components/dashboard/RentalsTab.tsx
@@ -4,6 +4,7 @@ import RentalTransactionList from '../rentals/RentalTransactionList';
 // import RentalTransactionDetail from '../rentals/RentalTransactionDetail'; // Keep commented if not yet implemented
 import SearchBox from '../ui/SearchBox';
 import { PlusCircle, ArrowLeft } from 'lucide-react'; // Unused icons like Filter, CalendarIcon removed
+import Button from '@mui/material/Button';
 import { RentalTransaction } from '../../types';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -127,12 +128,9 @@ const RentalsTab: React.FC = () => {
       </div>
 
       <div className="mb-6 flex justify-end">
-        <button
-          onClick={handleOpenRentalFormForCreate}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue hover:bg-brand-blue/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue transition-colors"
-        >
-          <PlusCircle className="h-5 w-5 mr-2" />New Rental Transaction
-        </button>
+        <Button variant="contained" color="primary" onClick={handleOpenRentalFormForCreate} startIcon={<PlusCircle className="h-5 w-5" />} sx={{ textTransform: 'none' }}>
+          New Rental Transaction
+        </Button>
       </div>
 
       {/* This is the crucial part: RentalTransactionList should only receive props it expects. */}

--- a/src/components/pages/CustomerFormPage.tsx
+++ b/src/components/pages/CustomerFormPage.tsx
@@ -4,6 +4,7 @@ import CustomerForm from '../CustomerForm';
 import { Customer } from '../../types';
 import { getCustomer } from '../../services/api/customers';
 import { useCustomers } from '../../context/CustomerContext';
+import { useRentalTransactions } from '../../context/RentalTransactionContext';
 
 const CustomerFormPage: React.FC = () => {
   const navigate = useNavigate();
@@ -12,6 +13,7 @@ const CustomerFormPage: React.FC = () => {
   const [customer, setCustomer] = useState<Customer | null>(location.state?.customer || null);
   const [loading, setLoading] = useState<boolean>(!!id && !customer);
   const { refreshData: refreshCustomerData } = useCustomers();
+  const { fetchCustomersForSelection } = useRentalTransactions();
 
   useEffect(() => {
     if (id && !customer) {
@@ -34,6 +36,7 @@ const CustomerFormPage: React.FC = () => {
         customer={customer}
         onSave={(newId) => {
           refreshCustomerData();
+          fetchCustomersForSelection();
           if (location.state?.returnToRental && newId) {
             navigate('/rentals/new', { state: { selectedCustomerId: String(newId) } });
           } else {

--- a/src/components/pages/CustomerFormPage.tsx
+++ b/src/components/pages/CustomerFormPage.tsx
@@ -8,7 +8,7 @@ import { useCustomers } from '../../context/CustomerContext';
 const CustomerFormPage: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id?: string }>();
-  const location = useLocation() as { state?: { customer?: Customer } };
+  const location = useLocation() as { state?: { customer?: Customer; returnToRental?: boolean } };
   const [customer, setCustomer] = useState<Customer | null>(location.state?.customer || null);
   const [loading, setLoading] = useState<boolean>(!!id && !customer);
   const { refreshData: refreshCustomerData } = useCustomers();
@@ -32,7 +32,14 @@ const CustomerFormPage: React.FC = () => {
     <div className="p-4">
       <CustomerForm
         customer={customer}
-        onSave={() => { refreshCustomerData(); navigate('/customers'); }}
+        onSave={(newId) => {
+          refreshCustomerData();
+          if (location.state?.returnToRental && newId) {
+            navigate('/rentals/new', { state: { selectedCustomerId: String(newId) } });
+          } else {
+            navigate('/customers');
+          }
+        }}
         onCancel={() => navigate(-1)}
       />
     </div>

--- a/src/components/pages/RentalFormPage.tsx
+++ b/src/components/pages/RentalFormPage.tsx
@@ -8,7 +8,7 @@ import { useRentalTransactions } from '../../context/RentalTransactionContext';
 const RentalFormPage: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id?: string }>();
-  const location = useLocation() as { state?: { rental?: RentalTransaction } };
+  const location = useLocation() as { state?: { rental?: RentalTransaction; selectedCustomerId?: string } };
 
   const [rental, setRental] = useState<RentalTransaction | null>(location.state?.rental || null);
   const [loading, setLoading] = useState<boolean>(!!id && !location.state?.rental);
@@ -45,6 +45,7 @@ const RentalFormPage: React.FC = () => {
     <div className="p-4">
       <RentalTransactionForm
         rental={rental}
+        defaultCustomerId={location.state?.selectedCustomerId}
         onSave={() => { refreshRentalTransactions(); navigate('/rentals'); }}
         onCancel={() => navigate(-1)}
       />

--- a/src/components/pages/RentalFormPage.tsx
+++ b/src/components/pages/RentalFormPage.tsx
@@ -17,7 +17,7 @@ const RentalFormPage: React.FC = () => {
   useEffect(() => {
     if (!id) return;
 
-    if (!rental || !rental.rental_items) {
+    if (!rental || !Array.isArray(rental.rental_items) || rental.rental_items.length === 0) {
       setLoading(true);
       Promise.all([
         getRental(Number(id)),

--- a/src/components/pages/RentalFormPage.tsx
+++ b/src/components/pages/RentalFormPage.tsx
@@ -11,11 +11,14 @@ const RentalFormPage: React.FC = () => {
   const location = useLocation() as { state?: { rental?: RentalTransaction } };
 
   const [rental, setRental] = useState<RentalTransaction | null>(location.state?.rental || null);
-  const [loading, setLoading] = useState<boolean>(!!id && !rental);
+  const [loading, setLoading] = useState<boolean>(!!id && !location.state?.rental);
   const { refreshRentalTransactions } = useRentalTransactions();
 
   useEffect(() => {
-    if (id && !rental) {
+    if (!id) return;
+
+    if (!rental || !rental.rental_items) {
+      setLoading(true);
       Promise.all([
         getRental(Number(id)),
         fetchRentalDetailsByRentalId(Number(id), { records: 100, skip: 0 }),

--- a/src/components/rentals/RentalCustomerSection.tsx
+++ b/src/components/rentals/RentalCustomerSection.tsx
@@ -1,28 +1,37 @@
 import React from 'react';
 import { Customer as CustomerType } from '../../types';
-import { Loader2, User } from 'lucide-react';
+import { Loader2, User, PlusCircle, ChevronDown } from 'lucide-react';
 import AutocompleteField from '../ui/AutocompleteField';
+import Button from '@mui/material/Button';
 
 interface Props {
   customerId: string;
   customers: CustomerType[];
   loadingCustomers: boolean;
+  status: string;
+  statusOptions: string[];
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
+  statusError?: string;
   inputClass: string;
   labelClass: string;
   iconClass: string;
+  onAddCustomer: () => void;
 }
 
 const RentalCustomerSection: React.FC<Props> = ({
   customerId,
   customers,
   loadingCustomers,
+  status,
+  statusOptions,
   handleChange,
   error,
+  statusError,
   inputClass,
   labelClass,
   iconClass,
+  onAddCustomer,
 }) => (
   <fieldset className="grid grid-cols-1 gap-y-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">
@@ -32,7 +41,7 @@ const RentalCustomerSection: React.FC<Props> = ({
       <label htmlFor="customer_id" className={labelClass}>
         Customer <span className="text-red-500">*</span>
       </label>
-      <div className="mt-1 relative rounded-md shadow-sm">
+      <div className="mt-1 relative rounded-md shadow-sm flex space-x-2">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           {loadingCustomers ? (
             <Loader2 className={`${iconClass} animate-spin`} />
@@ -40,7 +49,7 @@ const RentalCustomerSection: React.FC<Props> = ({
             <User className={iconClass} />
           )}
         </div>
-        <div className="pl-10">
+        <div className="flex-1 pl-10">
           <AutocompleteField
             name="customer_id"
             id="customer_id"
@@ -52,8 +61,32 @@ const RentalCustomerSection: React.FC<Props> = ({
             placeholder={loadingCustomers ? 'Loading...' : 'Select Customer'}
           />
         </div>
+        <Button variant="outlined" size="small" onClick={onAddCustomer} startIcon={<PlusCircle className="h-4 w-4" />} sx={{ minWidth: 'fit-content', textTransform: 'none' }}>
+          Add
+        </Button>
       </div>
       {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+    </div>
+    <div>
+      <label htmlFor="status" className={labelClass}>
+        Status <span className="text-red-500">*</span>
+      </label>
+      <div className="mt-1 relative rounded-md shadow-sm">
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <ChevronDown className={iconClass} />
+        </div>
+        <div className="pl-10">
+          <AutocompleteField
+            name="status"
+            id="status"
+            value={status}
+            onChange={handleChange}
+            options={statusOptions.map((s) => ({ label: s, value: s }))}
+            placeholder="Select status"
+          />
+        </div>
+      </div>
+      {statusError && <p className="text-xs text-red-500 mt-1">{statusError}</p>}
     </div>
   </fieldset>
 );

--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -77,8 +77,8 @@ const RentalItemsSection: React.FC<Props> = ({
                   <OutlinedTextField
                     type="number"
                     id={`item_rate_${index}`}
-                    value={item.unit_rental_rate}
-                    onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
+                    value={item.rental_rate}
+                    onChange={(e) => handleItemChange(index, 'rental_rate', e.target.value)}
                     className={`${inputClass} text-xs`}
                     inputProps={{ step: '0.01', min: '0' }}
                     placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
@@ -88,8 +88,8 @@ const RentalItemsSection: React.FC<Props> = ({
                       ),
                     }}
                   />
-                  {formErrors[`rental_items.${index}.unit_rental_rate`] && (
-                    <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>
+                  {formErrors[`rental_items.${index}.rental_rate`] && (
+                    <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.rental_rate`]}</p>
                   )}
                 </td>
                 <td className="p-2 text-right">
@@ -149,8 +149,8 @@ const RentalItemsSection: React.FC<Props> = ({
                 <OutlinedTextField
                   type="number"
                   id={`item_rate_${index}`}
-                  value={item.unit_rental_rate}
-                  onChange={(e) => handleItemChange(index, 'unit_rental_rate', e.target.value)}
+                  value={item.rental_rate}
+                  onChange={(e) => handleItemChange(index, 'rental_rate', e.target.value)}
                   className={`${inputClass} text-xs`}
                   inputProps={{ step: '0.01', min: '0' }}
                   placeholder={item.default_equipment_rate !== null ? String(item.default_equipment_rate) : '0.00'}
@@ -162,8 +162,8 @@ const RentalItemsSection: React.FC<Props> = ({
                     ),
                   }}
                 />
-                {formErrors[`rental_items.${index}.unit_rental_rate`] && (
-                  <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.unit_rental_rate`]}</p>
+                {formErrors[`rental_items.${index}.rental_rate`] && (
+                  <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.rental_rate`]}</p>
                 )}
               </div>
             </div>

--- a/src/components/rentals/RentalShippingBilling.tsx
+++ b/src/components/rentals/RentalShippingBilling.tsx
@@ -79,45 +79,47 @@ const RentalShippingBilling: React.FC<Props> = ({
             className={inputClass}
           />
         </div>
-        <div>
-          <label htmlFor="shipping_pincode" className={labelClass}>Shipping Pincode</label>
-          <OutlinedTextField
-            type="text"
-            id="shipping_pincode"
-            name="shipping_pincode"
-            value={data.shipping_pincode || ''}
-            onChange={handleChange}
-            className={inputClass}
-            inputProps={{ maxLength: 6 }}
-            InputProps={{
-              endAdornment: shippingPincodeDetailsLoading ? (
-                <InputAdornment position="end">
-                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-                </InputAdornment>
-              ) : undefined,
-            }}
-          />
-          {errors.shipping_pincode && (
-            <p className="text-xs text-red-500 mt-1">{errors.shipping_pincode}</p>
-          )}
-          {shippingPincodeError && (
-            <p className="text-xs text-red-500 mt-1">{shippingPincodeError}</p>
-          )}
-        </div>
-        <div>
-          <label htmlFor="shipping_area" className={labelClass}>Shipping Area</label>
-          <AutocompleteField
-            id="shipping_area"
-            name="shipping_area"
-            value={data.shipping_area || ''}
-            onChange={handleChange}
-            options={shippingAreaOptions}
-            placeholder="Select Area"
-            freeSolo
-          />
-          {errors.shipping_area && (
-            <p className="text-xs text-red-500 mt-1">{errors.shipping_area}</p>
-          )}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="shipping_pincode" className={labelClass}>Shipping Pincode</label>
+            <OutlinedTextField
+              type="text"
+              id="shipping_pincode"
+              name="shipping_pincode"
+              value={data.shipping_pincode || ''}
+              onChange={handleChange}
+              className={inputClass}
+              inputProps={{ maxLength: 6 }}
+              InputProps={{
+                endAdornment: shippingPincodeDetailsLoading ? (
+                  <InputAdornment position="end">
+                    <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                  </InputAdornment>
+                ) : undefined,
+              }}
+            />
+            {errors.shipping_pincode && (
+              <p className="text-xs text-red-500 mt-1">{errors.shipping_pincode}</p>
+            )}
+            {shippingPincodeError && (
+              <p className="text-xs text-red-500 mt-1">{shippingPincodeError}</p>
+            )}
+          </div>
+          <div>
+            <label htmlFor="shipping_area" className={labelClass}>Shipping Area</label>
+            <AutocompleteField
+              id="shipping_area"
+              name="shipping_area"
+              value={data.shipping_area || ''}
+              onChange={handleChange}
+              options={shippingAreaOptions}
+              placeholder="Select Area"
+              freeSolo
+            />
+            {errors.shipping_area && (
+              <p className="text-xs text-red-500 mt-1">{errors.shipping_area}</p>
+            )}
+          </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
@@ -159,45 +161,47 @@ const RentalShippingBilling: React.FC<Props> = ({
             className={inputClass}
           />
         </div>
-        <div>
-          <label htmlFor="billing_pincode" className={labelClass}>Billing Pincode</label>
-          <OutlinedTextField
-            type="text"
-            id="billing_pincode"
-            name="billing_pincode"
-            value={data.billing_pincode || ''}
-            onChange={handleChange}
-            className={inputClass}
-            inputProps={{ maxLength: 6 }}
-            InputProps={{
-              endAdornment: billingPincodeDetailsLoading ? (
-                <InputAdornment position="end">
-                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-                </InputAdornment>
-              ) : undefined,
-            }}
-          />
-          {errors.billing_pincode && (
-            <p className="text-xs text-red-500 mt-1">{errors.billing_pincode}</p>
-          )}
-          {billingPincodeError && (
-            <p className="text-xs text-red-500 mt-1">{billingPincodeError}</p>
-          )}
-        </div>
-        <div>
-          <label htmlFor="billing_area" className={labelClass}>Billing Area</label>
-          <AutocompleteField
-            id="billing_area"
-            name="billing_area"
-            value={data.billing_area || ''}
-            onChange={handleChange}
-            options={billingAreaOptions}
-            placeholder="Select Area"
-            freeSolo
-          />
-          {errors.billing_area && (
-            <p className="text-xs text-red-500 mt-1">{errors.billing_area}</p>
-          )}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="billing_pincode" className={labelClass}>Billing Pincode</label>
+            <OutlinedTextField
+              type="text"
+              id="billing_pincode"
+              name="billing_pincode"
+              value={data.billing_pincode || ''}
+              onChange={handleChange}
+              className={inputClass}
+              inputProps={{ maxLength: 6 }}
+              InputProps={{
+                endAdornment: billingPincodeDetailsLoading ? (
+                  <InputAdornment position="end">
+                    <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                  </InputAdornment>
+                ) : undefined,
+              }}
+            />
+            {errors.billing_pincode && (
+              <p className="text-xs text-red-500 mt-1">{errors.billing_pincode}</p>
+            )}
+            {billingPincodeError && (
+              <p className="text-xs text-red-500 mt-1">{billingPincodeError}</p>
+            )}
+          </div>
+          <div>
+            <label htmlFor="billing_area" className={labelClass}>Billing Area</label>
+            <AutocompleteField
+              id="billing_area"
+              name="billing_area"
+              value={data.billing_area || ''}
+              onChange={handleChange}
+              options={billingAreaOptions}
+              placeholder="Select Area"
+              freeSolo
+            />
+            {errors.billing_area && (
+              <p className="text-xs text-red-500 mt-1">{errors.billing_area}</p>
+            )}
+          </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>

--- a/src/components/rentals/RentalStatusDates.tsx
+++ b/src/components/rentals/RentalStatusDates.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { CalendarDays, ChevronDown } from 'lucide-react';
+import { CalendarDays } from 'lucide-react';
 import { RentalTransactionFormData } from '../../types';
 
 import DatePickerField from "../ui/DatePickerField";
-import AutocompleteField from '../ui/AutocompleteField';
 interface Props {
-  data: Pick<RentalTransactionFormData, 'rental_date' | 'expected_return_date' | 'status'>;
+  data: Pick<RentalTransactionFormData, 'rental_date' | 'expected_return_date'>;
   numberOfDays: number;
-  errors: Partial<Record<'rental_date' | 'expected_return_date' | 'status', string>>;
+  errors: Partial<Record<'rental_date' | 'expected_return_date', string>>;
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   inputClass: string;
   labelClass: string;
   iconClass: string;
-  statusOptions: string[];
 }
 
 const RentalStatusDates: React.FC<Props> = ({
@@ -23,9 +21,8 @@ const RentalStatusDates: React.FC<Props> = ({
   inputClass,
   labelClass,
   iconClass,
-  statusOptions,
 }) => (
-  <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
+  <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-3">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">
       Rental Details
     </legend>
@@ -67,27 +64,6 @@ const RentalStatusDates: React.FC<Props> = ({
       </p>
     </div>
 
-    <div>
-      <label htmlFor="status" className={labelClass}>
-        Status <span className="text-red-500">*</span>
-      </label>
-      <div className="mt-1 relative rounded-md shadow-sm">
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <ChevronDown className={iconClass} />
-        </div>
-        <div className="pl-10">
-          <AutocompleteField
-            name="status"
-            id="status"
-            value={data.status || ''}
-            onChange={handleChange}
-            options={statusOptions.map((s) => ({ label: s, value: s }))}
-            placeholder="Select status"
-          />
-        </div>
-      </div>
-      {errors.status && <p className="text-xs text-red-500 mt-1">{errors.status}</p>}
-    </div>
   </fieldset>
 );
 

--- a/src/components/rentals/RentalTransactionCard.tsx
+++ b/src/components/rentals/RentalTransactionCard.tsx
@@ -24,12 +24,14 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!rental.rental_items) {
+    if (!rental.rental_items || rental.rental_items.some(it => !('equipment_name' in it))) {
       fetchRentalDetailsByRentalId(rental.rental_id, { records: 20, skip: 0 }).then(res => {
         if (res.success && Array.isArray(res.data)) {
           setItems(res.data as any);
         }
       });
+    } else {
+      setItems(rental.rental_items);
     }
   }, [rental]);
 

--- a/src/components/rentals/RentalTransactionCard.tsx
+++ b/src/components/rentals/RentalTransactionCard.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { RentalTransaction } from '../../types';
 import { CalendarCheck2, User, Edit3, Trash2, Loader2, FileText, IndianRupee, Tag, CalendarClock, CheckCircle, XCircle, Clock, AlertTriangle } from 'lucide-react';
+import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
 import { useCrud } from '../../context/CrudContext';
 import ConfirmationModal from '../ui/ConfirmationModal';
 import { useRentalTransactions } from '../../context/RentalTransactionContext';
@@ -112,23 +114,13 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
                 Rental ID: {rental.rental_id}
               </h3>
             </div>
-            <div className="flex space-x-2 rental-card-menu-button">
-              <button
-                onClick={handleEdit}
-                disabled={crudLoading}
-                className="p-1 text-dark-text/60 hover:text-brand-blue rounded-full hover:bg-light-gray-100 disabled:opacity-50"
-                aria-label="Edit Rental"
-              >
+            <div className="flex space-x-1 rental-card-menu-button">
+              <IconButton onClick={handleEdit} disabled={crudLoading} size="small" color="primary">
                 <Edit3 size={20} />
-              </button>
-              <button
-                onClick={handleDeleteClick}
-                disabled={crudLoading}
-                className="p-1 text-red-600 hover:text-red-700 rounded-full hover:bg-light-gray-100 disabled:opacity-50"
-                aria-label="Delete Rental"
-              >
+              </IconButton>
+              <IconButton onClick={handleDeleteClick} disabled={crudLoading} size="small" color="error">
                 {crudLoading && isConfirmModalOpen ? <Loader2 size={20} className="animate-spin" /> : <Trash2 size={20} />}
-              </button>
+              </IconButton>
             </div>
           </div>
 
@@ -175,6 +167,9 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
                     {items.map(it => (
                       <li key={it.rental_detail_id} className="text-xs">
                         {it.equipment_name || `ID: ${it.equipment_id}`}
+                        {it.unit_rental_rate !== undefined && it.unit_rental_rate !== null && (
+                          <> - {formatCurrency(it.unit_rental_rate)}/day</>
+                        )}
                       </li>
                     ))}
                   </ul>
@@ -198,12 +193,9 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
         </div>
         <div className="p-4 mt-auto border-t border-light-gray-100 flex justify-between items-center">
           {getStatusChip(rental.status)}
-          <button
-            onClick={handleRecordPayment}
-            className="text-xs text-brand-blue hover:underline rental-card-menu-button"
-          >
+          <Button onClick={handleRecordPayment} size="small" color="primary" className="rental-card-menu-button" sx={{ textTransform: 'none' }}>
             Record Payment
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/components/rentals/RentalTransactionCard.tsx
+++ b/src/components/rentals/RentalTransactionCard.tsx
@@ -169,8 +169,8 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
                     {items.map(it => (
                       <li key={it.rental_detail_id} className="text-xs">
                         {it.equipment_name || `ID: ${it.equipment_id}`}
-                        {it.unit_rental_rate !== undefined && it.unit_rental_rate !== null && (
-                          <> - {formatCurrency(it.unit_rental_rate)}/day</>
+                        {it.rental_rate !== undefined && it.rental_rate !== null && (
+                          <> - {formatCurrency(it.rental_rate)}/day</>
                         )}
                       </li>
                     ))}

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -180,18 +180,18 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
     if (selected) {
       setFormData(prev => ({
         ...prev,
-        shipping_address: prev.shipping_address || selected.shipping_address || '',
-        shipping_area: prev.shipping_area || selected.shipping_area || '',
-        shipping_city: prev.shipping_city || selected.shipping_city || '',
-        shipping_state: prev.shipping_state || selected.shipping_state || '',
-        shipping_pincode: prev.shipping_pincode || selected.shipping_pincode || '',
-        billing_address: prev.billing_address || selected.shipping_address || '',
-        billing_area: prev.billing_area || selected.shipping_area || '',
-        billing_city: prev.billing_city || selected.shipping_city || '',
-        billing_state: prev.billing_state || selected.shipping_state || '',
-        billing_pincode: prev.billing_pincode || selected.shipping_pincode || '',
-        mobile_number: prev.mobile_number || selected.mobile_number_1 || '',
-        email: prev.email || selected.email || '',
+        shipping_address: selected.shipping_address || '',
+        shipping_area: selected.shipping_area || '',
+        shipping_city: selected.shipping_city || '',
+        shipping_state: selected.shipping_state || '',
+        shipping_pincode: selected.shipping_pincode || '',
+        billing_address: selected.shipping_address || '',
+        billing_area: selected.shipping_area || '',
+        billing_city: selected.shipping_city || '',
+        billing_state: selected.shipping_state || '',
+        billing_pincode: selected.shipping_pincode || '',
+        mobile_number: selected.mobile_number_1 || '',
+        email: selected.email || '',
       }));
       setOriginalShippingPincode(selected.shipping_pincode || '');
       setOriginalBillingPincode(selected.shipping_pincode || '');
@@ -516,30 +516,31 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             customerId={formData.customer_id}
             customers={customers}
             loadingCustomers={loadingCustomers}
+            status={formData.status}
+            statusOptions={RENTAL_STATUSES_FORM}
             handleChange={handleChange}
             error={formErrors.customer_id}
+            statusError={formErrors.status}
             inputClass={inputClass}
             labelClass={labelClass}
             iconClass={iconClass}
+            onAddCustomer={() => navigate('/customers/new')}
           />
 
           <RentalStatusDates
             data={{
               rental_date: formData.rental_date,
               expected_return_date: formData.expected_return_date,
-              status: formData.status,
             }}
             numberOfDays={numberOfDays}
             errors={{
               rental_date: formErrors.rental_date,
               expected_return_date: formErrors.expected_return_date,
-              status: formErrors.status,
             }}
             handleChange={handleChange}
             inputClass={inputClass}
             labelClass={labelClass}
             iconClass={iconClass}
-            statusOptions={RENTAL_STATUSES_FORM}
           />
 
           <div>

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -135,13 +135,15 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   ]);
 
   useEffect(() => {
-    if (!isEditing && defaultCustomerId && customers.length > 0) {
+    if (!isEditing && defaultCustomerId) {
       const exists = customers.find(c => String(c.customer_id) === defaultCustomerId);
       if (exists) {
         setFormData(prev => ({ ...prev, customer_id: defaultCustomerId }));
+      } else if (!loadingCustomers) {
+        fetchCustomersForSelection();
       }
     }
-  }, [defaultCustomerId, isEditing, customers]);
+  }, [defaultCustomerId, isEditing, customers, loadingCustomers, fetchCustomersForSelection]);
 
   useEffect(() => {
     if (rental) {

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -400,6 +400,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
       total_amount: calculatedTotalAmount, // Add calculated total amount
       rental_items: formData.rental_items.map(item => ({
         equipment_id: parseInt(item.equipment_id, 10),
+        unit_rental_rate: parseFloat(item.unit_rental_rate) || 0,
         ...(isEditing &&
           rental?.rental_items?.find(ri => String(ri.equipment_id) === item.equipment_id)?.rental_detail_id
             ? { rental_detail_id: rental.rental_items.find(ri => String(ri.equipment_id) === item.equipment_id)!.rental_detail_id }
@@ -424,10 +425,12 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               ? updateRentalDetail(item.rental_detail_id, {
                   rental_id: rental.rental_id,
                   equipment_id: item.equipment_id,
+                  unit_rental_rate: item.unit_rental_rate,
                 })
               : createRentalDetail({
                   rental_id: rental.rental_id,
                   equipment_id: item.equipment_id,
+                  unit_rental_rate: item.unit_rental_rate,
                 })
           )
         );
@@ -440,6 +443,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               createRentalDetail({
                 rental_id: Number(newId),
                 equipment_id: item.equipment_id,
+                unit_rental_rate: item.unit_rental_rate,
               })
             )
           );

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -40,6 +40,7 @@ interface RentalTransactionFormProps {
   rental?: RentalTransaction | null;
   onSave: () => void;
   onCancel: () => void;
+  defaultCustomerId?: string;
 }
 
 const initialFormData: RentalTransactionFormData = {
@@ -68,6 +69,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   rental,
   onSave,
   onCancel,
+  defaultCustomerId,
 }) => {
   const [formData, setFormData] = useState<RentalTransactionFormData>(initialFormData);
   const [formErrors, setFormErrors] = useState<Partial<Record<keyof RentalTransactionFormData | `rental_items.${number}.equipment_id` | `rental_items.${number}.rental_rate`, string>>>({});
@@ -131,6 +133,15 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
     paymentPlans.length, loadingPaymentPlans, refreshPaymentPlans,
     availableEquipment.length, loadingEquipment, refreshAvailableEquipment
   ]);
+
+  useEffect(() => {
+    if (!isEditing && defaultCustomerId && customers.length > 0) {
+      const exists = customers.find(c => String(c.customer_id) === defaultCustomerId);
+      if (exists) {
+        setFormData(prev => ({ ...prev, customer_id: defaultCustomerId }));
+      }
+    }
+  }, [defaultCustomerId, isEditing, customers]);
 
   useEffect(() => {
     if (rental) {
@@ -524,7 +535,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             inputClass={inputClass}
             labelClass={labelClass}
             iconClass={iconClass}
-            onAddCustomer={() => navigate('/customers/new')}
+            onAddCustomer={() => navigate('/customers/new', { state: { returnToRental: true } })}
           />
 
           <RentalStatusDates

--- a/src/components/ui/AutocompleteField.tsx
+++ b/src/components/ui/AutocompleteField.tsx
@@ -59,13 +59,17 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
     }
   };
 
+  const inputValue = freeSolo
+    ? (typeof value === 'string' ? value : selectedOption?.label || '')
+    : selectedOption?.label || '';
+
   return (
     <Autocomplete
       freeSolo={freeSolo}
       options={options}
       getOptionLabel={(option) => option.label}
       value={selectedOption}
-      inputValue={typeof value === 'string' ? value : selectedOption?.label || ''}
+      inputValue={inputValue}
       onChange={handleChange}
       onInputChange={handleInputChange}
       loading={loading}

--- a/src/components/ui/AutocompleteField.tsx
+++ b/src/components/ui/AutocompleteField.tsx
@@ -32,7 +32,10 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
   freeSolo = false,
 }) => {
   const selectedOption =
-    options.find((opt) => String(opt.value) === String(value)) || null;
+    options.find((opt) => String(opt.value) === String(value)) ||
+    (freeSolo && value
+      ? { label: String(value), value: String(value) }
+      : null);
 
   const handleChange = (_: any, newValue: AutocompleteOption | null) => {
     const syntheticEvent = {
@@ -44,13 +47,27 @@ const AutocompleteField: React.FC<AutocompleteFieldProps> = ({
     onChange(syntheticEvent);
   };
 
+  const handleInputChange = (_: any, newInputValue: string) => {
+    if (freeSolo) {
+      const syntheticEvent = {
+        target: {
+          name,
+          value: newInputValue,
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+      onChange(syntheticEvent);
+    }
+  };
+
   return (
     <Autocomplete
       freeSolo={freeSolo}
       options={options}
       getOptionLabel={(option) => option.label}
       value={selectedOption}
+      inputValue={typeof value === 'string' ? value : selectedOption?.label || ''}
       onChange={handleChange}
+      onInputChange={handleInputChange}
       loading={loading}
       disabled={disabled}
       renderInput={(params) => (

--- a/src/services/api/equipment.ts
+++ b/src/services/api/equipment.ts
@@ -46,3 +46,18 @@ export const searchEquipment = (queryValue: string, paginationParams?: Paginatio
   }
   return fetchFromApi('GET', params);
 };
+
+export const fetchEquipmentByIds = (ids: number[]): Promise<ApiResponse> => {
+  if (ids.length === 0) {
+    return Promise.resolve({ success: true, data: [] } as ApiResponse);
+  }
+  const qString = ids.map(id => `(equipment_id~equals~${id})`).join('');
+  const params: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    q: qString,
+    records: ids.length,
+    skip: 0,
+  };
+  return fetchFromApi('GET', params);
+};

--- a/src/services/api/payments.ts
+++ b/src/services/api/payments.ts
@@ -1,10 +1,11 @@
 import { ApiResponse, PaginationParams } from '../../types';
-import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, listRecords, searchRecords } from './core';
+import { createRecordGeneric, updateRecordGeneric, deleteRecord, listRecords, searchRecords, getRecord } from './core';
+import { getRental } from './rentals';
 
 const TABLE = 'payments';
 const RENTALS_TABLE = 'rental_transactions';
 
-const fetchRental = (id: number) => getRecord(RENTALS_TABLE, id);
+const fetchRental = (id: number) => getRental(id);
 const updateRentalRecord = (id: number, data: Record<string, any>) => updateRecordGeneric(RENTALS_TABLE, id, data);
 
 export const fetchPayments = (params: PaginationParams): Promise<ApiResponse> => listRecords(TABLE, params);

--- a/src/services/api/rentals.ts
+++ b/src/services/api/rentals.ts
@@ -1,5 +1,5 @@
 import { ApiResponse, PaginationParams } from '../../types';
-import { createRecordGeneric, updateRecordGeneric, deleteRecord, getRecord, listRecords } from './core';
+import { createRecordGeneric, updateRecordGeneric, deleteRecord, listRecords, getRecord } from './core';
 
 const RENTAL_TRANSACTIONS_TABLE = 'rental_transactions';
 const RENTAL_DETAILS_TABLE = 'rental_details';
@@ -8,7 +8,13 @@ export const fetchRentals = (params: PaginationParams): Promise<ApiResponse> => 
 export const createRental = (data: Record<string, any>): Promise<ApiResponse> => createRecordGeneric(RENTAL_TRANSACTIONS_TABLE, data, false);
 export const updateRental = (id: number, data: Record<string, any>): Promise<ApiResponse> => updateRecordGeneric(RENTAL_TRANSACTIONS_TABLE, id, data, false);
 export const deleteRental = (id: number): Promise<ApiResponse> => deleteRecord(RENTAL_TRANSACTIONS_TABLE, id);
-export const getRental = (id: number): Promise<ApiResponse> => getRecord(RENTAL_TRANSACTIONS_TABLE, id);
+export const getRental = (id: number): Promise<ApiResponse> => {
+  return listRecords(RENTAL_TRANSACTIONS_TABLE, {
+    records: 1,
+    skip: 0,
+    filters: { rental_id: id },
+  });
+};
 
 export const fetchRentalDetailsByRentalId = (rentalId: number, paginationParams?: PaginationParams): Promise<ApiResponse> => {
   const params = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,7 +140,7 @@ export interface RentalItem {
   rental_id: number;
   equipment_id: number;
   equipment_name?: string; // For display
-  unit_rental_rate: number; // Rate per day for this specific item in this rental
+  rental_rate: number; // Rate per day for this specific item in this rental
   // Potentially other fields like discount, subtotal per item
 }
 
@@ -149,7 +149,7 @@ export interface RentalItemFormData {
   temp_id: string; // e.g., crypto.randomUUID()
   equipment_id: string; // Selected equipment ID (from form select)
   equipment_name?: string; // For display in the form
-  unit_rental_rate: string; // Input as string, specific rate for this rental item
+  rental_rate: string; // Input as string, specific rate for this rental item
   // Default rate from equipment master can be pre-filled
   default_equipment_rate?: number | null;
 }


### PR DESCRIPTION
## Summary
- show shipping pincode and area fields next to each other
- show billing pincode and area fields next to each other
- load rental details when editing so selected items appear

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68416fab5e70832189b50386af706bbb