### PR TITLE
Enable data refresh on menu navigation

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -131,6 +131,31 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
                       payments: '/payments',
                     };
                     navigate(paths[tab.id] || '/');
+
+                    switch (tab.id) {
+                      case 'customers':
+                        refreshCustomerData();
+                        break;
+                      case 'equipment':
+                        refreshEquipmentData();
+                        break;
+                      case 'rentals':
+                        refreshRentalTransactions();
+                        break;
+                      case 'payments':
+                        refreshPayments();
+                        break;
+                      case 'masters':
+                        refreshEqCategories();
+                        refreshPaymentPlans();
+                        break;
+                      case 'maintenance':
+                        refreshMaintenanceRecords();
+                        break;
+                      default:
+                        break;
+                    }
+
                     if (sidebarOpen && window.innerWidth < 768) setSidebarOpen(false);
                   }}
                   className={`w-full flex items-center px-4 py-2 rounded-md transition-colors ${activeTab === tab.id ? 'bg-brand-blue text-white shadow-sm' : 'text-dark-text hover:bg-light-gray-100'}`}


### PR DESCRIPTION
## Summary
- trigger data refresh whenever a sidebar menu tab is clicked

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684194ea0c608321ac1c8df35a8b4b32