### PR TITLE
Update payments page to show rental info

### DIFF
--- a/src/components/dashboard/PaymentsTab.tsx
+++ b/src/components/dashboard/PaymentsTab.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { usePayments } from '../../context/PaymentContext';
 import PaymentList from '../payments/PaymentList';
 import SearchBox from '../ui/SearchBox';
-import { PlusCircle } from 'lucide-react';
 import { Payment } from '../../types';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,9 +9,6 @@ const PaymentsTab: React.FC = () => {
   const { searchQuery, setSearchQuery } = usePayments();
   const navigate = useNavigate();
 
-  const handleOpenPaymentFormForCreate = () => {
-    navigate('/payments/new');
-  };
 
   const handleOpenPaymentFormForEdit = (item: Payment) => {
     navigate(`/payments/${item.payment_id}/edit`, { state: { payment: item } });
@@ -28,12 +24,7 @@ const PaymentsTab: React.FC = () => {
         <div className="w-full md:max-w-xs mb-4 md:mb-0">
           <SearchBox value={searchQuery} onChange={setSearchQuery} placeholder="Search payments..." />
         </div>
-        <button
-          onClick={handleOpenPaymentFormForCreate}
-          className="w-full md:w-auto inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-brand-blue hover:bg-brand-blue/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue transition-colors"
-        >
-          <PlusCircle className="h-5 w-5 mr-2" />Record Payment
-        </button>
+        {/* Record Payment button removed as payments are created from rental page */}
       </div>
       <PaymentList onEditPayment={handleOpenPaymentFormForEdit} onViewPayment={handleViewPayment} />
     </>

--- a/src/components/payments/PaymentDetail.tsx
+++ b/src/components/payments/PaymentDetail.tsx
@@ -22,7 +22,14 @@ const PaymentDetail: React.FC<PaymentDetailProps> = ({ payment, onClose, isModal
         </button>
       </div>
       <div className="space-y-2">
-        <div className="text-sm text-dark-text">Rental ID: {payment.rental_id}</div>
+        <div className="text-sm text-dark-text">
+          Customer: {payment.customer_name || `Rental #${payment.rental_id}`}
+        </div>
+        {payment.rented_from && (
+          <div className="text-sm text-dark-text">
+            Rented From: {formatDate(payment.rented_from)}
+          </div>
+        )}
         <div className="text-sm text-dark-text">Nature: {payment.nature || 'rental'}</div>
         <div className="text-sm text-dark-text">Date: {formatDate(payment.payment_date)}</div>
         <div className="text-sm text-dark-text flex items-center">

--- a/src/components/payments/PaymentList.tsx
+++ b/src/components/payments/PaymentList.tsx
@@ -40,7 +40,7 @@ const PaymentList: React.FC<PaymentListProps> = ({ onEditPayment, onViewPayment 
     return (
       <EmptyState
         title={searchQuery ? 'No payments match your search' : 'No Payments Found'}
-        message={searchQuery ? 'Try a different search term.' : 'Get started by recording a payment.'}
+        message={searchQuery ? 'Try a different search term.' : 'No payments available.'}
         icon={<IndianRupee className="w-16 h-16 text-gray-400" />}
       />
     );
@@ -53,7 +53,8 @@ const PaymentList: React.FC<PaymentListProps> = ({ onEditPayment, onViewPayment 
           <thead className="bg-light-gray-50">
             <tr>
               <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">ID</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Rental ID</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Customer</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Rented From</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Nature</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Date</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Amount</th>

--- a/src/components/payments/PaymentListItem.tsx
+++ b/src/components/payments/PaymentListItem.tsx
@@ -33,7 +33,10 @@ const PaymentListItem: React.FC<PaymentListItemProps> = ({ payment, onEdit, onVi
           {payment.payment_id}
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">
-          {payment.rental_id}
+          {payment.customer_name || `Rental #${payment.rental_id}`}
+        </td>
+        <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">
+          {payment.rented_from ? formatDate(payment.rented_from) : '-'}
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">
           {payment.nature || 'rental'}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,8 @@ export interface Payment {
   payment_mode: string | null;
   payment_reference: string | null;
   notes: string | null;
+  customer_name?: string;
+  rented_from?: string;
 }
 
 export interface PaymentFormData {


### PR DESCRIPTION
## Summary
- remove `Record Payment` button from Payments tab
- display customer name and rented-from date in payment list and detail views
- adjust empty state message on payments list
- extend `Payment` type with optional `customer_name` and `rented_from` fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419628dc048321985e7869e7be2250