### PR TITLE
Disable fields for completed rentals

### DIFF
--- a/src/components/rentals/RentalCustomerSection.tsx
+++ b/src/components/rentals/RentalCustomerSection.tsx
@@ -17,6 +17,7 @@ interface Props {
   labelClass: string;
   iconClass: string;
   onAddCustomer: () => void;
+  disabled?: boolean;
 }
 
 const RentalCustomerSection: React.FC<Props> = ({
@@ -32,6 +33,7 @@ const RentalCustomerSection: React.FC<Props> = ({
   labelClass,
   iconClass,
   onAddCustomer,
+  disabled = false,
 }) => (
   <fieldset className="grid grid-cols-1 gap-y-6 md:grid-cols-2">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">
@@ -57,11 +59,11 @@ const RentalCustomerSection: React.FC<Props> = ({
             onChange={handleChange}
             options={customers.map((c) => ({ label: c.full_name, value: String(c.customer_id) }))}
             loading={loadingCustomers}
-            disabled={loadingCustomers}
+            disabled={loadingCustomers || disabled}
             placeholder={loadingCustomers ? 'Loading...' : 'Select Customer'}
           />
         </div>
-        <Button variant="outlined" size="small" onClick={onAddCustomer} startIcon={<PlusCircle className="h-4 w-4" />} sx={{ minWidth: 'fit-content', textTransform: 'none' }}>
+        <Button variant="outlined" size="small" onClick={onAddCustomer} disabled={disabled} startIcon={<PlusCircle className="h-4 w-4" />} sx={{ minWidth: 'fit-content', textTransform: 'none' }}>
           Add
         </Button>
       </div>
@@ -83,6 +85,7 @@ const RentalCustomerSection: React.FC<Props> = ({
             onChange={handleChange}
             options={statusOptions.map((s) => ({ label: s, value: s }))}
             placeholder="Select status"
+            disabled={disabled}
           />
         </div>
       </div>

--- a/src/components/rentals/RentalItemsSection.tsx
+++ b/src/components/rentals/RentalItemsSection.tsx
@@ -17,6 +17,7 @@ interface Props {
   inputClass: string;
   labelClass: string;
   isEditing?: boolean;
+  disabled?: boolean;
 }
 
 const RentalItemsSection: React.FC<Props> = ({
@@ -30,6 +31,7 @@ const RentalItemsSection: React.FC<Props> = ({
   inputClass,
   labelClass,
   isEditing = false,
+  disabled = false,
 }) => (
   <fieldset>
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">Rental Items</legend>
@@ -65,7 +67,7 @@ const RentalItemsSection: React.FC<Props> = ({
                         label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
                       }))}
                     loading={loadingEquipment}
-                    disabled={loadingEquipment}
+                    disabled={loadingEquipment || disabled}
                     placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
                     className="w-full"
                   />
@@ -83,6 +85,7 @@ const RentalItemsSection: React.FC<Props> = ({
                     step={0.01}
                     startAdornment={<InputAdornment position="start">₹</InputAdornment>}
                     className={`${inputClass} text-xs`}
+                    readOnly={disabled}
                   />
                   {formErrors[`rental_items.${index}.rental_rate`] && (
                     <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.rental_rate`]}</p>
@@ -94,6 +97,7 @@ const RentalItemsSection: React.FC<Props> = ({
                     onClick={() => removeItem(index)}
                     className="p-1 text-red-500 hover:text-red-700 rounded-full hover:bg-red-100"
                     title="Remove Item"
+                    disabled={disabled}
                   >
                     <Trash2 size={16} />
                   </button>
@@ -133,7 +137,7 @@ const RentalItemsSection: React.FC<Props> = ({
                       label: `${eq.equipment_name} (SN: ${eq.serial_number || 'N/A'}) - Rate: ${formatCurrency(eq.rental_rate)}`,
                     }))}
                   loading={loadingEquipment}
-                  disabled={loadingEquipment}
+                  disabled={loadingEquipment || disabled}
                   placeholder={loadingEquipment ? 'Loading...' : 'Select Equipment'}
                 />
                 {formErrors[`rental_items.${index}.equipment_id`] && (
@@ -151,6 +155,7 @@ const RentalItemsSection: React.FC<Props> = ({
                   step={0.01}
                   startAdornment={<InputAdornment position="start">₹</InputAdornment>}
                   className={`${inputClass} text-xs`}
+                  readOnly={disabled}
                 />
                 {formErrors[`rental_items.${index}.rental_rate`] && (
                   <p className="text-xs text-red-500 mt-1">{formErrors[`rental_items.${index}.rental_rate`]}</p>
@@ -164,6 +169,7 @@ const RentalItemsSection: React.FC<Props> = ({
     <button
       type="button"
       onClick={addItem}
+      disabled={disabled}
       className="mt-3 inline-flex items-center px-3 py-1.5 border border-dashed border-brand-blue text-brand-blue text-xs font-medium rounded-md hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-brand-blue"
     >
       <PackagePlus size={16} className="mr-2" /> Add Rental Item

--- a/src/components/rentals/RentalShippingBilling.tsx
+++ b/src/components/rentals/RentalShippingBilling.tsx
@@ -38,6 +38,7 @@ interface Props {
   copyBillingToShipping: () => void;
   inputClass: string;
   labelClass: string;
+  disabled?: boolean;
 }
 
 const RentalShippingBilling: React.FC<Props> = ({
@@ -56,13 +57,14 @@ const RentalShippingBilling: React.FC<Props> = ({
   copyBillingToShipping,
   inputClass,
   labelClass,
+  disabled = false,
 }) => (
   <fieldset className="space-y-6">
     <legend className="text-lg font-medium text-dark-text mb-2">Shipping &amp; Billing</legend>
     <div className="flex gap-4 text-xs">
-      <Button variant="outlined" size="small" onClick={copyShippingToBilling}
+      <Button variant="outlined" size="small" onClick={copyShippingToBilling} disabled={disabled}
         >Copy Shipping to Billing</Button>
-      <Button variant="outlined" size="small" onClick={copyBillingToShipping}
+      <Button variant="outlined" size="small" onClick={copyBillingToShipping} disabled={disabled}
         >Copy Billing to Shipping</Button>
     </div>
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -77,6 +79,7 @@ const RentalShippingBilling: React.FC<Props> = ({
             multiline
             rows={2}
             className={inputClass}
+            disabled={disabled}
           />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -97,6 +100,7 @@ const RentalShippingBilling: React.FC<Props> = ({
                   </InputAdornment>
                 ) : undefined,
               }}
+              disabled={disabled}
             />
             {errors.shipping_pincode && (
               <p className="text-xs text-red-500 mt-1">{errors.shipping_pincode}</p>
@@ -115,6 +119,7 @@ const RentalShippingBilling: React.FC<Props> = ({
               options={shippingAreaOptions}
               placeholder="Select Area"
               freeSolo
+              disabled={disabled}
             />
             {errors.shipping_area && (
               <p className="text-xs text-red-500 mt-1">{errors.shipping_area}</p>
@@ -124,27 +129,29 @@ const RentalShippingBilling: React.FC<Props> = ({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label htmlFor="shipping_city" className={labelClass}>Shipping City</label>
-            <OutlinedTextField
-              type="text"
-              id="shipping_city"
-              name="shipping_city"
-              value={data.shipping_city || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: true }}
-            />
+          <OutlinedTextField
+            type="text"
+            id="shipping_city"
+            name="shipping_city"
+            value={data.shipping_city || ''}
+            onChange={handleChange}
+            className={inputClass}
+            InputProps={{ readOnly: true }}
+            disabled={disabled}
+          />
           </div>
           <div>
             <label htmlFor="shipping_state" className={labelClass}>Shipping State</label>
-            <OutlinedTextField
-              type="text"
-              id="shipping_state"
-              name="shipping_state"
-              value={data.shipping_state || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: true }}
-            />
+          <OutlinedTextField
+            type="text"
+            id="shipping_state"
+            name="shipping_state"
+            value={data.shipping_state || ''}
+            onChange={handleChange}
+            className={inputClass}
+            InputProps={{ readOnly: true }}
+            disabled={disabled}
+          />
           </div>
         </div>
       </div>
@@ -159,27 +166,29 @@ const RentalShippingBilling: React.FC<Props> = ({
             multiline
             rows={2}
             className={inputClass}
+            disabled={disabled}
           />
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label htmlFor="billing_pincode" className={labelClass}>Billing Pincode</label>
-            <OutlinedTextField
-              type="text"
-              id="billing_pincode"
-              name="billing_pincode"
-              value={data.billing_pincode || ''}
-              onChange={handleChange}
-              className={inputClass}
-              inputProps={{ maxLength: 6 }}
-              InputProps={{
-                endAdornment: billingPincodeDetailsLoading ? (
-                  <InputAdornment position="end">
-                    <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-                  </InputAdornment>
-                ) : undefined,
-              }}
-            />
+          <OutlinedTextField
+            type="text"
+            id="billing_pincode"
+            name="billing_pincode"
+            value={data.billing_pincode || ''}
+            onChange={handleChange}
+            className={inputClass}
+            inputProps={{ maxLength: 6 }}
+            InputProps={{
+              endAdornment: billingPincodeDetailsLoading ? (
+                <InputAdornment position="end">
+                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                </InputAdornment>
+              ) : undefined,
+            }}
+            disabled={disabled}
+          />
             {errors.billing_pincode && (
               <p className="text-xs text-red-500 mt-1">{errors.billing_pincode}</p>
             )}
@@ -197,6 +206,7 @@ const RentalShippingBilling: React.FC<Props> = ({
               options={billingAreaOptions}
               placeholder="Select Area"
               freeSolo
+              disabled={disabled}
             />
             {errors.billing_area && (
               <p className="text-xs text-red-500 mt-1">{errors.billing_area}</p>
@@ -206,27 +216,29 @@ const RentalShippingBilling: React.FC<Props> = ({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label htmlFor="billing_city" className={labelClass}>Billing City</label>
-            <OutlinedTextField
-              type="text"
-              id="billing_city"
-              name="billing_city"
-              value={data.billing_city || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: true }}
-            />
+          <OutlinedTextField
+            type="text"
+            id="billing_city"
+            name="billing_city"
+            value={data.billing_city || ''}
+            onChange={handleChange}
+            className={inputClass}
+            InputProps={{ readOnly: true }}
+            disabled={disabled}
+          />
           </div>
           <div>
             <label htmlFor="billing_state" className={labelClass}>Billing State</label>
-            <OutlinedTextField
-              type="text"
-              id="billing_state"
-              name="billing_state"
-              value={data.billing_state || ''}
-              onChange={handleChange}
-              className={inputClass}
-              InputProps={{ readOnly: true }}
-            />
+          <OutlinedTextField
+            type="text"
+            id="billing_state"
+            name="billing_state"
+            value={data.billing_state || ''}
+            onChange={handleChange}
+            className={inputClass}
+            InputProps={{ readOnly: true }}
+            disabled={disabled}
+          />
           </div>
         </div>
       </div>
@@ -243,6 +255,7 @@ const RentalShippingBilling: React.FC<Props> = ({
           value={data.mobile_number || ''}
           onChange={handleChange}
           className={inputClass}
+          disabled={disabled}
         />
       </div>
       <div>
@@ -256,6 +269,7 @@ const RentalShippingBilling: React.FC<Props> = ({
           value={data.email || ''}
           onChange={handleChange}
           className={inputClass}
+          disabled={disabled}
         />
       </div>
     </div>

--- a/src/components/rentals/RentalStatusDates.tsx
+++ b/src/components/rentals/RentalStatusDates.tsx
@@ -11,6 +11,7 @@ interface Props {
   inputClass: string;
   labelClass: string;
   iconClass: string;
+  disabled?: boolean;
 }
 
 const RentalStatusDates: React.FC<Props> = ({
@@ -21,6 +22,7 @@ const RentalStatusDates: React.FC<Props> = ({
   inputClass,
   labelClass,
   iconClass,
+  disabled = false,
 }) => (
   <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-3">
     <legend className="text-lg font-medium text-dark-text col-span-full mb-2">
@@ -35,6 +37,7 @@ const RentalStatusDates: React.FC<Props> = ({
         value={data.rental_date}
         onChange={handleChange}
         required
+        disabled={disabled}
       />
       {errors.rental_date && (
         <p className="text-xs text-red-500 mt-1">{errors.rental_date}</p>
@@ -50,6 +53,7 @@ const RentalStatusDates: React.FC<Props> = ({
         value={data.expected_return_date || ''}
         onChange={handleChange}
         required
+        disabled={disabled}
       />
       {errors.expected_return_date && (
         <p className="text-xs text-red-500 mt-1">{errors.expected_return_date}</p>

--- a/src/components/rentals/RentalTransactionForm.tsx
+++ b/src/components/rentals/RentalTransactionForm.tsx
@@ -121,6 +121,8 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
   } = usePincodeLookup(formData.billing_pincode, shouldFetchBilling);
 
   const isEditing = !!rental;
+  const isCompleted = isEditing && !!rental?.actual_return_date;
+  const fieldsDisabled = isCompleted;
 
   const [showAddressSection, setShowAddressSection] = useState<boolean>(!isEditing);
 
@@ -516,6 +518,9 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
         <h2 className="text-xl font-semibold text-brand-blue flex items-center">
           <CalendarCheck2 className="h-6 w-6 mr-2 text-brand-blue" />
           {isEditing ? 'Edit Rental Transaction' : 'New Rental Transaction'}
+          {isCompleted && (
+            <span className="ml-3 px-2.5 py-1 text-xs font-semibold rounded-full bg-teal-100 text-teal-700">Completed</span>
+          )}
         </h2>
         <button onClick={onCancel} className="p-2 rounded-full hover:bg-light-gray-100">
           <X className="h-5 w-5 text-dark-text" />
@@ -542,6 +547,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             labelClass={labelClass}
             iconClass={iconClass}
             onAddCustomer={() => navigate('/customers/new', { state: { returnToRental: true } })}
+            disabled={fieldsDisabled}
           />
 
           <RentalStatusDates
@@ -558,6 +564,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             inputClass={inputClass}
             labelClass={labelClass}
             iconClass={iconClass}
+            disabled={fieldsDisabled}
           />
 
           <div>
@@ -566,6 +573,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               size="small"
               onClick={() => setShowAddressSection(s => !s)}
               className="mb-2"
+              disabled={fieldsDisabled}
             >
               {showAddressSection ? 'Hide Shipping & Billing' : 'Show Shipping & Billing'}
             </Button>
@@ -599,6 +607,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                 copyBillingToShipping={copyBillingToShipping}
                 inputClass={inputClass}
                 labelClass={labelClass}
+                disabled={fieldsDisabled}
               />
             )}
           </div>
@@ -611,6 +620,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                 checked={updateCustomerAddress}
                 onChange={(e) => setUpdateCustomerAddress(e.target.checked)}
                 className="h-4 w-4 text-brand-blue border-gray-300 rounded"
+                disabled={fieldsDisabled}
               />
               <label htmlFor="update_customer_address" className="ml-2 text-sm text-dark-text">
                 Update customer with this shipping address
@@ -629,6 +639,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             inputClass={inputClass}
             labelClass={labelClass}
             isEditing={isEditing}
+            disabled={fieldsDisabled}
           />
 
           <fieldset className="grid grid-cols-1 gap-y-6 gap-x-4 md:grid-cols-2">
@@ -647,7 +658,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                     onChange={handleChange}
                     options={paymentPlans.map(pt => ({ label: pt.plan_name, value: pt.plan_name }))}
                     loading={loadingPaymentPlans}
-                    disabled={loadingPaymentPlans}
+                    disabled={loadingPaymentPlans || fieldsDisabled}
                     placeholder={loadingPaymentPlans ? 'Loading...' : 'Select Payment Term'}
                     freeSolo
                   />
@@ -672,6 +683,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
                   value={formData.notes || ''}
                   onChange={handleChange}
                   className={`${inputClass} pl-8`}
+                  disabled={fieldsDisabled}
                 />
               </div>
             </div>
@@ -688,7 +700,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
             </button>
             <button
               type="submit"
-              disabled={crudLoading || loadingCustomers || loadingPaymentPlans || loadingEquipment}
+              disabled={fieldsDisabled || crudLoading || loadingCustomers || loadingPaymentPlans || loadingEquipment}
               className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-blue hover:bg-brand-blue/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-blue disabled:opacity-50 flex items-center"
             >
               {crudLoading ? (
@@ -698,7 +710,7 @@ const RentalTransactionForm: React.FC<RentalTransactionFormProps> = ({
               )}
               {isEditing ? 'Save Changes' : 'Create Rental'}
             </button>
-            {!isEditing && (
+            {!isEditing && !fieldsDisabled && (
               <button
                 type="button"
                 onClick={() => handleSubmit(true)}

--- a/src/components/ui/DatePickerField.tsx
+++ b/src/components/ui/DatePickerField.tsx
@@ -9,9 +9,10 @@ interface DatePickerFieldProps {
   value: string;
   onChange: React.ChangeEventHandler<HTMLInputElement>;
   required?: boolean;
+  disabled?: boolean;
 }
 
-const DatePickerField: React.FC<DatePickerFieldProps> = ({ label, name, value, onChange, required }) => {
+const DatePickerField: React.FC<DatePickerFieldProps> = ({ label, name, value, onChange, required, disabled = false }) => {
   const handleChange = (date: Dayjs | null) => {
     const syntheticEvent = {
       target: { name, value: date ? date.format('DD/MM/YYYY') : '' }
@@ -25,7 +26,7 @@ const DatePickerField: React.FC<DatePickerFieldProps> = ({ label, name, value, o
       format="DD/MM/YYYY"
       value={value ? dayjs(value, 'DD/MM/YYYY') : null}
       onChange={handleChange}
-      slotProps={{ textField: { fullWidth: true, name, id: name, required } }}
+      slotProps={{ textField: { fullWidth: true, name, id: name, required, disabled } }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- prevent editing completed rentals
- show a Completed badge on rental form
- pass disabled option through rental form subcomponents
- add optional disabled prop to DatePicker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef2894108321804bcdcb33bfd420