### PR TITLE
Add rental return workflow

### DIFF
--- a/src/components/rentals/RentalTransactionCard.tsx
+++ b/src/components/rentals/RentalTransactionCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { RentalTransaction } from '../../types';
-import { CalendarCheck2, User, Edit3, Trash2, Loader2, FileText, IndianRupee, Tag, CalendarClock, CheckCircle, XCircle, Clock, AlertTriangle } from 'lucide-react';
+import { CalendarCheck2, User, Edit3, Trash2, Loader2, FileText, IndianRupee, Tag, CalendarClock, CheckCircle, XCircle, Clock, AlertTriangle, Undo2 } from 'lucide-react';
 import IconButton from '@mui/material/IconButton';
 import Button from '@mui/material/Button';
 import { useCrud } from '../../context/CrudContext';
@@ -9,6 +9,7 @@ import { useRentalTransactions } from '../../context/RentalTransactionContext';
 import { formatDate, formatCurrency } from '../../utils/formatting';
 import { fetchRentalDetailsByRentalId } from '../../services/api/rentals';
 import { useNavigate, useLocation } from 'react-router-dom';
+import ReturnRentalDialog from './ReturnRentalDialog';
 
 interface RentalTransactionCardProps {
   rental: RentalTransaction; // This will now include customer_name and payment_term_name
@@ -20,6 +21,7 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
   const { deleteItem, loading: crudLoading } = useCrud();
   const { refreshRentalTransactions } = useRentalTransactions();
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [showReturnDialog, setShowReturnDialog] = useState(false);
   const [items, setItems] = useState(rental.rental_items || []);
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,6 +53,11 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
     navigate('/payments/new', {
       state: { payment: { rental_id: rental.rental_id }, from: location.pathname },
     });
+  };
+
+  const handleReturnClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowReturnDialog(true);
   };
 
   const confirmDelete = async () => {
@@ -198,9 +205,12 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
         </div>
         <div className="p-4 mt-auto border-t border-light-gray-100 flex justify-between items-center">
           {getStatusChip(rental.status)}
-          <Button onClick={handleRecordPayment} size="small" color="primary" className="rental-card-menu-button" sx={{ textTransform: 'none' }}>
-            Record Payment
-          </Button>
+          <div className="space-x-2">
+            <Button onClick={handleReturnClick} size="small" color="secondary" className="rental-card-menu-button" sx={{ textTransform: 'none' }} startIcon={<Undo2 size={16} />}>Return</Button>
+            <Button onClick={handleRecordPayment} size="small" color="primary" className="rental-card-menu-button" sx={{ textTransform: 'none' }}>
+              Record Payment
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -213,6 +223,7 @@ const RentalTransactionCard: React.FC<RentalTransactionCardProps> = ({ rental, o
         isLoading={crudLoading}
         confirmText="Delete"
       />
+      <ReturnRentalDialog open={showReturnDialog} onClose={() => setShowReturnDialog(false)} rental={rental} />
     </>
   );
 };

--- a/src/components/rentals/ReturnRentalDialog.tsx
+++ b/src/components/rentals/ReturnRentalDialog.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import TextField from '@mui/material/TextField';
+import AutocompleteField from '../ui/AutocompleteField';
+import DatePickerField from '../ui/DatePickerField';
+import { RentalTransaction, RentalItem } from '../../types';
+import { useCrud } from '../../context/CrudContext';
+import { useRentalTransactions } from '../../context/RentalTransactionContext';
+import { useEquipment } from '../../context/EquipmentContext';
+import { fetchRentalDetailsByRentalId } from '../../services/api/rentals';
+import dayjs from 'dayjs';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  rental: RentalTransaction;
+}
+
+const ReturnRentalDialog: React.FC<Props> = ({ open, onClose, rental }) => {
+  const { updateItem, createItem, loading } = useCrud();
+  const { refreshRentalTransactions } = useRentalTransactions();
+  const { refreshEquipmentData } = useEquipment();
+  const [items, setItems] = useState<RentalItem[]>(rental.rental_items || []);
+  const [selected, setSelected] = useState<number[]>([]);
+  const [payment, setPayment] = useState('');
+  const [returnDate, setReturnDate] = useState<string>('');
+  const [paymentMode, setPaymentMode] = useState<string>('Cash');
+  const [paymentRef, setPaymentRef] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      if (!rental.rental_items || rental.rental_items.some(it => !('equipment_name' in it))) {
+        fetchRentalDetailsByRentalId(rental.rental_id, { records: 20, skip: 0 }).then(res => {
+          if (res.success && Array.isArray(res.data)) {
+            setItems(res.data as any);
+            setSelected((res.data as any).map((it: any) => it.equipment_id));
+          }
+        });
+      } else {
+        setItems(rental.rental_items);
+        setSelected(rental.rental_items.map(it => it.equipment_id));
+      }
+      setPayment('');
+      setReturnDate(dayjs().format('DD/MM/YYYY'));
+      setPaymentMode('Cash');
+      setPaymentRef('');
+    }
+  }, [open, rental]);
+
+  const toggleItem = (id: number) => {
+    setSelected(prev => (prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]));
+  };
+
+  const handleConfirm = async () => {
+    try {
+      await Promise.all(selected.map(id => updateItem('equipment', id, { status: 'Available' })));
+      if (selected.length === items.length) {
+        await updateItem('rental_transactions', rental.rental_id, {
+          status: 'Returned/Completed',
+          actual_return_date: dayjs(returnDate, 'DD/MM/YYYY').format('YYYY-MM-DD'),
+        });
+        await updateItem('customers', rental.customer_id, { has_active_rentals: 0 });
+      }
+      if (payment && Number(payment) > 0) {
+        await createItem('payments', {
+          rental_id: rental.rental_id,
+          payment_date: dayjs(returnDate, 'DD/MM/YYYY').format('YYYY-MM-DD'),
+          payment_amount: Number(payment),
+          payment_mode: paymentMode,
+          payment_reference: paymentMode !== 'Cash' ? paymentRef || null : null,
+          nature: 'rental',
+        });
+      }
+      refreshEquipmentData();
+      refreshRentalTransactions();
+      onClose();
+    } catch (err) {
+      console.error('Failed to process return', err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Return Rental Items</DialogTitle>
+      <DialogContent dividers>
+        <div className="space-y-2">
+          {items.map(item => (
+            <FormControlLabel
+              key={item.equipment_id}
+              control={
+                <Checkbox
+                  checked={selected.includes(item.equipment_id)}
+                  onChange={() => toggleItem(item.equipment_id)}
+                />
+              }
+              label={item.equipment_name || `ID: ${item.equipment_id}`}
+            />
+          ))}
+        </div>
+        <div className="mt-4 space-y-4">
+          <DatePickerField label="Return Date" name="return_date" value={returnDate} onChange={(e) => setReturnDate(e.target.value)} />
+          <TextField
+            label="Payment Amount"
+            type="number"
+            fullWidth
+            value={payment}
+            onChange={e => setPayment(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          {payment && Number(payment) > 0 && (
+            <>
+              <AutocompleteField
+                name="payment_mode"
+                value={paymentMode}
+                onChange={(e) => setPaymentMode(e.target.value)}
+                options={[{ label: 'Cash', value: 'Cash' }, { label: 'NEFT/RTGS', value: 'NEFT/RTGS' }, { label: 'IMPS', value: 'IMPS' }, { label: 'Credit Card', value: 'Credit Card' }, { label: 'Debit Card', value: 'Debit Card' }, { label: 'UPI', value: 'UPI' }, { label: 'Others', value: 'Others' }]}
+              />
+              {paymentMode !== 'Cash' && (
+                <TextField
+                  label="Reference"
+                  fullWidth
+                  value={paymentRef}
+                  onChange={e => setPaymentRef(e.target.value)}
+                  InputLabelProps={{ shrink: true }}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading}>Cancel</Button>
+        <Button onClick={handleConfirm} disabled={loading || selected.length === 0} variant="contained" color="primary">
+          Return
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ReturnRentalDialog;


### PR DESCRIPTION
## Summary
- add `ReturnRentalDialog` for returning rented items
- support marking equipment available and closing the rental
- allow optional final payment when returning
- expose new `Return` button on rental cards
- ask for return date, payment mode and reference when recording payment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef27da0483218a88e9da6157324d