### PR TITLE
Add OTP login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PaymentPlanProvider } from './context/PaymentPlanContext';
 import { MaintenanceRecordProvider } from './context/MaintenanceRecordContext';
 import { RentalTransactionProvider } from './context/RentalTransactionContext'; // Import new provider
 import { PaymentProvider } from './context/PaymentContext';
+import { AuthProvider } from './context/AuthContext';
 import Dashboard from './components/Dashboard';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import CustomerFormPage from './components/pages/CustomerFormPage';
@@ -24,6 +25,7 @@ import EquipmentCategoryFormPage from './components/pages/EquipmentCategoryFormP
 import PaymentFormPage from './components/pages/PaymentFormPage';
 import PaymentDetailPage from './components/pages/PaymentDetailPage';
 import NotFound from './components/pages/NotFound';
+import LoginPage from './components/pages/LoginPage';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -42,6 +44,7 @@ function App() {
     <ThemeProvider theme={theme}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <CssBaseline />
+        <AuthProvider>
         <CrudProvider>
       <CustomerProvider>
         <EquipmentProvider>
@@ -84,6 +87,7 @@ function App() {
                       <Route path="masters/payment-plans/new" element={<PaymentPlanFormPage />} />
                       <Route path="masters/payment-plans/:id/edit" element={<PaymentPlanFormPage />} />
                     </Route>
+                    <Route path="/login" element={<LoginPage />} />
                     <Route path="*" element={<NotFound />} />
                   </Routes>
                   </PaymentProvider>
@@ -94,6 +98,7 @@ function App() {
         </EquipmentProvider>
       </CustomerProvider>
     </CrudProvider>
+        </AuthProvider>
       </LocalizationProvider>
     </ThemeProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import PaymentFormPage from './components/pages/PaymentFormPage';
 import PaymentDetailPage from './components/pages/PaymentDetailPage';
 import NotFound from './components/pages/NotFound';
 import LoginPage from './components/pages/LoginPage';
+import RequireAuth from './components/RequireAuth';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -45,54 +46,64 @@ function App() {
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <CssBaseline />
         <AuthProvider>
-        <CrudProvider>
-      <CustomerProvider>
-        <EquipmentProvider>
-          <EquipmentCategoryProvider>
-            <PaymentPlanProvider>
-              <MaintenanceRecordProvider>
-                <RentalTransactionProvider>
-                  <PaymentProvider>
-                    <Routes>
-                    <Route path="/" element={<Dashboard sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />}>
-                      <Route index element={<Navigate to="customers" replace />} />
+          <CrudProvider>
+            <CustomerProvider>
+              <EquipmentProvider>
+                <EquipmentCategoryProvider>
+                  <PaymentPlanProvider>
+                    <MaintenanceRecordProvider>
+                      <RentalTransactionProvider>
+                        <PaymentProvider>
+                          <Routes>
+                            <Route element={<RequireAuth />}>
+                              <Route
+                                path="/"
+                                element={
+                                  <Dashboard
+                                    sidebarOpen={sidebarOpen}
+                                    setSidebarOpen={setSidebarOpen}
+                                  />
+                                }
+                              >
+                                <Route index element={<Navigate to="customers" replace />} />
 
-                      <Route path="customers" element={<></>} />
-                      <Route path="customers/new" element={<CustomerFormPage />} />
-                      <Route path="customers/:id/edit" element={<CustomerFormPage />} />
-                      <Route path="customers/:id" element={<CustomerDetailPage />} />
+                                <Route path="customers" element={<></>} />
+                                <Route path="customers/new" element={<CustomerFormPage />} />
+                                <Route path="customers/:id/edit" element={<CustomerFormPage />} />
+                                <Route path="customers/:id" element={<CustomerDetailPage />} />
 
-                      <Route path="equipment" element={<></>} />
-                      <Route path="equipment/new" element={<EquipmentFormPage />} />
-                      <Route path="equipment/:id/edit" element={<EquipmentFormPage />} />
-                      <Route path="equipment/:id" element={<EquipmentDetailPage />} />
+                                <Route path="equipment" element={<></>} />
+                                <Route path="equipment/new" element={<EquipmentFormPage />} />
+                                <Route path="equipment/:id/edit" element={<EquipmentFormPage />} />
+                                <Route path="equipment/:id" element={<EquipmentDetailPage />} />
 
-                      <Route path="rentals" element={<></>} />
-                      <Route path="rentals/new" element={<RentalFormPage />} />
-                      <Route path="rentals/:id/edit" element={<RentalFormPage />} />
+                                <Route path="rentals" element={<></>} />
+                                <Route path="rentals/new" element={<RentalFormPage />} />
+                                <Route path="rentals/:id/edit" element={<RentalFormPage />} />
 
-                      <Route path="payments" element={<></>} />
-                      <Route path="payments/new" element={<PaymentFormPage />} />
-                      <Route path="payments/:id/edit" element={<PaymentFormPage />} />
-                      <Route path="payments/:id" element={<PaymentDetailPage />} />
+                                <Route path="payments" element={<></>} />
+                                <Route path="payments/new" element={<PaymentFormPage />} />
+                                <Route path="payments/:id/edit" element={<PaymentFormPage />} />
+                                <Route path="payments/:id" element={<PaymentDetailPage />} />
 
-                      <Route path="maintenance" element={<></>} />
-                      <Route path="maintenance/new" element={<MaintenanceFormPage />} />
-                      <Route path="maintenance/:id/edit" element={<MaintenanceFormPage />} />
+                                <Route path="maintenance" element={<></>} />
+                                <Route path="maintenance/new" element={<MaintenanceFormPage />} />
+                                <Route path="maintenance/:id/edit" element={<MaintenanceFormPage />} />
 
-                      <Route path="masters/equipment-categories" element={<></>} />
-                      <Route path="masters/equipment-categories/new" element={<EquipmentCategoryFormPage />} />
-                      <Route path="masters/equipment-categories/:id/edit" element={<EquipmentCategoryFormPage />} />
-                      <Route path="masters/payment-plans" element={<></>} />
-                      <Route path="masters/payment-plans/new" element={<PaymentPlanFormPage />} />
-                      <Route path="masters/payment-plans/:id/edit" element={<PaymentPlanFormPage />} />
-                    </Route>
-                    <Route path="/login" element={<LoginPage />} />
-                    <Route path="*" element={<NotFound />} />
-                  </Routes>
-                  </PaymentProvider>
-                </RentalTransactionProvider>
-              </MaintenanceRecordProvider>
+                                <Route path="masters/equipment-categories" element={<></>} />
+                                <Route path="masters/equipment-categories/new" element={<EquipmentCategoryFormPage />} />
+                                <Route path="masters/equipment-categories/:id/edit" element={<EquipmentCategoryFormPage />} />
+                                <Route path="masters/payment-plans" element={<></>} />
+                                <Route path="masters/payment-plans/new" element={<PaymentPlanFormPage />} />
+                                <Route path="masters/payment-plans/:id/edit" element={<PaymentPlanFormPage />} />
+                              </Route>
+                            </Route>
+                            <Route path="/login" element={<LoginPage />} />
+                            <Route path="*" element={<NotFound />} />
+                          </Routes>
+                        </PaymentProvider>
+                      </RentalTransactionProvider>
+                    </MaintenanceRecordProvider>
             </PaymentPlanProvider>
           </EquipmentCategoryProvider>
         </EquipmentProvider>

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="40" viewBox="0 0 180 40">
+  <text x="0" y="30" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#1976d2">SurgiHire</text>
+</svg>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import {
-  RefreshCw, Menu, X, Users, Package, Calendar as CalendarIcon, Settings, IndianRupee, Wrench
+  RefreshCw,
+  Menu,
+  X,
+  Users,
+  Package,
+  Calendar as CalendarIcon,
+  Settings,
+  IndianRupee,
+  Wrench,
+  LogOut,
 } from 'lucide-react'; // Renamed Calendar to CalendarIcon to avoid conflict
 
 // Import context hooks
@@ -21,6 +30,7 @@ import RentalsTab from './dashboard/RentalsTab'; // Import new tab component
 import PaymentsTab from './dashboard/PaymentsTab';
 import Footer from './Footer';
 import { Outlet, useNavigate, useLocation, useMatch } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 interface DashboardProps {
   sidebarOpen: boolean;
@@ -30,6 +40,7 @@ interface DashboardProps {
 const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { logout } = useAuth();
   const [activeTab, setActiveTab] = useState('customers');
 
   const { refreshData: refreshCustomerData, loading: customersLoading } = useCustomers();
@@ -64,6 +75,11 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
       case 'maintenance': refreshMaintenanceRecords(); break;
       default: break;
     }
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
   };
 
   const isLoading = () => {
@@ -182,6 +198,12 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
                 {mainTabs.find(tab => tab.id === activeTab)?.label}
               </h1>
             </div>
+            <button
+              onClick={handleLogout}
+              className="inline-flex items-center px-3 py-2 text-sm rounded-md text-dark-text hover:bg-light-gray-100"
+            >
+              <LogOut className="h-4 w-4 mr-2" />Logout
+            </button>
           </div>
         </header>
 

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+/**
+ * Wraps protected routes and redirects unauthenticated users to the login page.
+ */
+const RequireAuth: React.FC = () => {
+  const { isLoggedIn } = useAuth();
+  const location = useLocation();
+
+  if (!isLoggedIn) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default RequireAuth;
+

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -3,9 +3,11 @@ import { Box, Button, Typography } from '@mui/material';
 import OutlinedTextField from '../ui/OutlinedTextField';
 import { requestOtp, validateOtp } from '../../services/auth';
 import { useAuth } from '../../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 const LoginPage: React.FC = () => {
   const { login } = useAuth();
+  const navigate = useNavigate();
   const [mobile, setMobile] = useState('');
   const [otp, setOtp] = useState('');
   const [otpRequested, setOtpRequested] = useState(false);
@@ -44,6 +46,7 @@ const LoginPage: React.FC = () => {
       setMessage(res.message);
       if (res.status_code === 200 && res.user?.apikey) {
         login(mobile, res.user.apikey);
+        navigate('/', { replace: true });
       }
     } catch (err) {
       setMessage('Failed to validate OTP.');

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import OutlinedTextField from '../ui/OutlinedTextField';
+import { requestOtp, validateOtp } from '../../services/auth';
+import { useAuth } from '../../context/AuthContext';
+
+const LoginPage: React.FC = () => {
+  const { login } = useAuth();
+  const [mobile, setMobile] = useState('');
+  const [otp, setOtp] = useState('');
+  const [otpRequested, setOtpRequested] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleRequestOtp = async () => {
+    if (!/^\d{10}$/.test(mobile)) {
+      setMessage('Please enter a valid 10 digit mobile number.');
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    try {
+      const res = await requestOtp(mobile);
+      setMessage(res.message);
+      if (res.status_code === 200) {
+        setOtpRequested(true);
+      }
+    } catch (err) {
+      setMessage('Failed to request OTP.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleValidateOtp = async () => {
+    if (!/^\d{6}$/.test(otp)) {
+      setMessage('Enter the 6 digit OTP.');
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    try {
+      const res = await validateOtp(mobile, otp);
+      setMessage(res.message);
+      if (res.status_code === 200 && res.user?.apikey) {
+        login(mobile, res.user.apikey);
+      }
+    } catch (err) {
+      setMessage('Failed to validate OTP.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box p={4} maxWidth={400} mx="auto">
+      <Typography variant="h5" gutterBottom>
+        Login
+      </Typography>
+      <OutlinedTextField
+        label="Mobile Number"
+        value={mobile}
+        onChange={e => setMobile(e.target.value)}
+        inputProps={{ maxLength: 10 }}
+      />
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleRequestOtp}
+        className="mt-4"
+        disabled={loading}
+      >
+        Request OTP
+      </Button>
+      {otpRequested && (
+        <>
+          <OutlinedTextField
+            label="OTP"
+            value={otp}
+            onChange={e => setOtp(e.target.value)}
+            inputProps={{ maxLength: 6 }}
+            className="mt-4"
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleValidateOtp}
+            className="mt-4"
+            disabled={loading}
+          >
+            Login
+          </Button>
+        </>
+      )}
+      {message && (
+        <Typography color="error" className="mt-2">
+          {message}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default LoginPage;

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Typography, Alert } from '@mui/material';
 import OutlinedTextField from '../ui/OutlinedTextField';
 import { requestOtp, validateOtp } from '../../services/auth';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import logo from '../../assets/logo.svg';
 
 const LoginPage: React.FC = () => {
   const { login } = useAuth();
@@ -56,50 +57,49 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <Box p={4} maxWidth={400} mx="auto">
-      <Typography variant="h5" gutterBottom>
-        Login
-      </Typography>
-      <OutlinedTextField
-        label="Mobile Number"
-        value={mobile}
-        onChange={e => setMobile(e.target.value)}
-        inputProps={{ maxLength: 10 }}
-      />
-      <Button
-        variant="contained"
-        color="primary"
-        onClick={handleRequestOtp}
-        className="mt-4"
-        disabled={loading}
-      >
-        Request OTP
-      </Button>
-      {otpRequested && (
-        <>
-          <OutlinedTextField
-            label="OTP"
-            value={otp}
-            onChange={e => setOtp(e.target.value)}
-            inputProps={{ maxLength: 6 }}
-            className="mt-4"
-          />
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleValidateOtp}
-            className="mt-4"
-            disabled={loading}
-          >
-            Login
-          </Button>
-        </>
-      )}
-      {message && (
-        <Typography color="error" className="mt-2">
-          {message}
+    <Box className="min-h-screen flex items-center justify-center bg-light-gray-50 p-4">
+      <Box className="w-full max-w-md bg-white rounded shadow-md p-6 space-y-4">
+        <img src={logo} alt="SurgiHire logo" className="h-12 mx-auto" />
+        <Typography variant="h5" align="center">
+          Login
         </Typography>
-      )}
+        <OutlinedTextField
+          label="Mobile Number"
+          value={mobile}
+          onChange={e => setMobile(e.target.value)}
+          inputProps={{ maxLength: 10 }}
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleRequestOtp}
+          className="mt-2"
+          disabled={loading}
+        >
+          Request OTP
+        </Button>
+        {otpRequested && (
+          <>
+            <OutlinedTextField
+              label="OTP"
+              value={otp}
+              onChange={e => setOtp(e.target.value)}
+              inputProps={{ maxLength: 6 }}
+              className="mt-4"
+            />
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleValidateOtp}
+              className="mt-2"
+              disabled={loading}
+            >
+              Login
+            </Button>
+          </>
+        )}
+        {message && <Alert severity="info">{message}</Alert>}
+      </Box>
     </Box>
   );
 };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  isLoggedIn: boolean;
+  mobile: string | null;
+  apiKey: string | null;
+  login: (mobile: string, apiKey: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+};
+
+interface Props {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<Props> = ({ children }) => {
+  const [mobile, setMobile] = useState<string | null>(
+    localStorage.getItem('mobile')
+  );
+  const [apiKey, setApiKey] = useState<string | null>(
+    localStorage.getItem('apiKey')
+  );
+
+  const login = (mob: string, key: string) => {
+    setMobile(mob);
+    setApiKey(key);
+    localStorage.setItem('mobile', mob);
+    localStorage.setItem('apiKey', key);
+  };
+
+  const logout = () => {
+    setMobile(null);
+    setApiKey(null);
+    localStorage.removeItem('mobile');
+    localStorage.removeItem('apiKey');
+  };
+
+  const value: AuthContextType = {
+    isLoggedIn: !!apiKey,
+    mobile,
+    apiKey,
+    login,
+    logout,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/services/api/core.ts
+++ b/src/services/api/core.ts
@@ -1,16 +1,24 @@
 import { ApiResponse, PaginationParams } from '../../types';
 
 // Use environment variables for API URL and Key
-const API_URL = import.meta.env.VITE_API_URL || 'https://surgihire.kodequick.com/api/v1.php';
-const API_KEY = import.meta.env.VITE_API_KEY || '';
+const API_URL =
+  import.meta.env.VITE_API_URL ||
+  'https://surgihire.kodequick.com/api/v1.php';
 
-if (!API_KEY) {
-  console.warn('API_KEY is not set in environment variables. Please create a .env file with VITE_API_KEY.');
+const DEFAULT_API_KEY = import.meta.env.VITE_API_KEY || '';
+
+if (!DEFAULT_API_KEY && !localStorage.getItem('apiKey')) {
+  console.warn(
+    'API_KEY is not set in environment variables. Please create a .env file with VITE_API_KEY.'
+  );
 }
 
-const baseHeaders = {
-  'X-Auth-Token': API_KEY,
-};
+const getApiKey = () =>
+  localStorage.getItem('apiKey') || DEFAULT_API_KEY;
+
+const getBaseHeaders = () => ({
+  'X-Auth-Token': getApiKey(),
+});
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000;
@@ -35,7 +43,7 @@ export const fetchFromApi = async (
 
     const fetchOptions: RequestInit = {
       method,
-      headers: { ...baseHeaders },
+      headers: { ...getBaseHeaders() },
     };
 
     if (method === 'POST') {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,40 @@
+export interface LoginResponse {
+  status_code: number;
+  status: string;
+  message: string;
+  user?: {
+    apikey: string;
+    [key: string]: any;
+  };
+}
+
+export const requestOtp = async (mobile: string): Promise<LoginResponse> => {
+  const response = await fetch(
+    'https://surgihire.kodequick.com/custom/login_request.php',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ mobile }),
+    }
+  );
+  return response.json();
+};
+
+export const validateOtp = async (
+  mobile: string,
+  otp: string
+): Promise<LoginResponse> => {
+  const response = await fetch(
+    'https://surgihire.kodequick.com/custom/login_validation.php',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ mobile, otp }),
+    }
+  );
+  return response.json();
+};

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -9,11 +9,17 @@ export interface LoginResponse {
 }
 
 export const requestOtp = async (mobile: string): Promise<LoginResponse> => {
-  const url = new URL(
-    'https://surgihire.kodequick.com/custom/login_request.php'
-  );
-  url.searchParams.set('mobile', mobile);
-  const response = await fetch(url.toString(), { method: 'POST' });
+  const url =
+    'https://surgihire.kodequick.com/custom/login_request.php';
+  const body = new URLSearchParams();
+  body.set('mobile', mobile);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
   return response.json();
 };
 
@@ -21,11 +27,17 @@ export const validateOtp = async (
   mobile: string,
   otp: string
 ): Promise<LoginResponse> => {
-  const url = new URL(
-    'https://surgihire.kodequick.com/custom/login_validation.php'
-  );
-  url.searchParams.set('mobile', mobile);
-  url.searchParams.set('otp', otp);
-  const response = await fetch(url.toString(), { method: 'POST' });
+  const url =
+    'https://surgihire.kodequick.com/custom/login_validation.php';
+  const body = new URLSearchParams();
+  body.set('mobile', mobile);
+  body.set('otp', otp);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
   return response.json();
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -9,16 +9,11 @@ export interface LoginResponse {
 }
 
 export const requestOtp = async (mobile: string): Promise<LoginResponse> => {
-  const response = await fetch(
-    'https://surgihire.kodequick.com/custom/login_request.php',
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ mobile }),
-    }
+  const url = new URL(
+    'https://surgihire.kodequick.com/custom/login_request.php'
   );
+  url.searchParams.set('mobile', mobile);
+  const response = await fetch(url.toString(), { method: 'POST' });
   return response.json();
 };
 
@@ -26,15 +21,11 @@ export const validateOtp = async (
   mobile: string,
   otp: string
 ): Promise<LoginResponse> => {
-  const response = await fetch(
-    'https://surgihire.kodequick.com/custom/login_validation.php',
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ mobile, otp }),
-    }
+  const url = new URL(
+    'https://surgihire.kodequick.com/custom/login_validation.php'
   );
+  url.searchParams.set('mobile', mobile);
+  url.searchParams.set('otp', otp);
+  const response = await fetch(url.toString(), { method: 'POST' });
   return response.json();
 };


### PR DESCRIPTION
## Summary
- support storing API key from localStorage in core API service
- add AuthContext to manage login state
- implement `LoginPage` with mobile number and OTP flow
- wire AuthProvider and login route into App routing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841f3ca135c8321a2d25f3dcba583f8