### PR TITLE
Add Users tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PaymentPlanProvider } from './context/PaymentPlanContext';
 import { MaintenanceRecordProvider } from './context/MaintenanceRecordContext';
 import { RentalTransactionProvider } from './context/RentalTransactionContext'; // Import new provider
 import { PaymentProvider } from './context/PaymentContext';
+import { UserProvider } from './context/UserContext';
 import { AuthProvider } from './context/AuthContext';
 import Dashboard from './components/Dashboard';
 import { Routes, Route, Navigate } from 'react-router-dom';
@@ -54,6 +55,7 @@ function App() {
                     <MaintenanceRecordProvider>
                       <RentalTransactionProvider>
                         <PaymentProvider>
+                          <UserProvider>
                           <Routes>
                             <Route element={<RequireAuth />}>
                               <Route
@@ -86,6 +88,8 @@ function App() {
                                 <Route path="payments/:id/edit" element={<PaymentFormPage />} />
                                 <Route path="payments/:id" element={<PaymentDetailPage />} />
 
+                                <Route path="users" element={<></>} />
+
                                 <Route path="maintenance" element={<></>} />
                                 <Route path="maintenance/new" element={<MaintenanceFormPage />} />
                                 <Route path="maintenance/:id/edit" element={<MaintenanceFormPage />} />
@@ -101,6 +105,7 @@ function App() {
                             <Route path="/login" element={<LoginPage />} />
                             <Route path="*" element={<NotFound />} />
                           </Routes>
+                          </UserProvider>
                         </PaymentProvider>
                       </RentalTransactionProvider>
                     </MaintenanceRecordProvider>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   IndianRupee,
   Wrench,
   LogOut,
+  User,
 } from 'lucide-react'; // Renamed Calendar to CalendarIcon to avoid conflict
 
 // Import context hooks
@@ -20,6 +21,7 @@ import { usePaymentPlans } from '../context/PaymentPlanContext';
 import { useMaintenanceRecords } from '../context/MaintenanceRecordContext';
 import { useRentalTransactions } from '../context/RentalTransactionContext'; // Import new context hook
 import { usePayments } from '../context/PaymentContext';
+import { useUsers } from '../context/UserContext';
 
 // Import Tab components
 import CustomerTab from './dashboard/CustomerTab';
@@ -28,6 +30,7 @@ import MastersTab from './dashboard/MastersTab';
 import MaintenanceTab from './dashboard/MaintenanceTab';
 import RentalsTab from './dashboard/RentalsTab'; // Import new tab component
 import PaymentsTab from './dashboard/PaymentsTab';
+import UsersTab from './dashboard/UsersTab';
 import Footer from './Footer';
 import { Outlet, useNavigate, useLocation, useMatch } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
@@ -50,6 +53,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
   const { refreshMaintenanceRecords, loading: maintenanceLoading } = useMaintenanceRecords();
   const { refreshRentalTransactions, loading: rentalsLoading } = useRentalTransactions(); // Add rentals refresh and loading
   const { refreshPayments, loading: paymentsLoading } = usePayments();
+  const { refreshUsers, loading: usersLoading } = useUsers();
 
   const mainTabs = [
     { id: 'customers', label: 'Customers', icon: <Users size={18} /> },
@@ -58,6 +62,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
     { id: 'payments', label: 'Payments', icon: <IndianRupee size={18} /> },
     { id: 'maintenance', label: 'Maintenance', icon: <Wrench size={18} /> },
     { id: 'masters', label: 'Masters', icon: <Settings size={18} /> },
+    { id: 'users', label: 'Users', icon: <User size={18} /> },
   ];
 
   const toggleSidebar = () => setSidebarOpen(!sidebarOpen);
@@ -71,6 +76,9 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
       case 'masters':
         refreshEqCategories();
         refreshPaymentPlans();
+        break;
+      case 'users':
+        refreshUsers();
         break;
       case 'maintenance': refreshMaintenanceRecords(); break;
       default: break;
@@ -88,6 +96,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
     if (activeTab === 'rentals') return rentalsLoading; // Add loading for rentals
     if (activeTab === 'payments') return paymentsLoading;
     if (activeTab === 'masters') return eqCategoriesLoading || ppLoading;
+    if (activeTab === 'users') return usersLoading;
     if (activeTab === 'maintenance') return maintenanceLoading;
     return false;
   };
@@ -100,6 +109,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
   const isMastersEqCatBase = useMatch({ path: '/masters/equipment-categories', end: true });
   const isMastersPayPlanBase = useMatch({ path: '/masters/payment-plans', end: true });
   const isPaymentsBase = useMatch({ path: '/payments', end: true });
+  const isUsersBase = useMatch({ path: '/users', end: true });
 
   const handleNavigateToEquipmentDetail = (equipmentId: number) => {
     navigate(`/equipment/${equipmentId}`);
@@ -119,6 +129,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
     else if (location.pathname.startsWith('/maintenance')) setActiveTab('maintenance');
     else if (location.pathname.startsWith('/masters')) setActiveTab('masters');
     else if (location.pathname.startsWith('/payments')) setActiveTab('payments');
+    else if (location.pathname.startsWith('/users')) setActiveTab('users');
     else setActiveTab('customers');
   }, [location.pathname]);
 
@@ -145,6 +156,7 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
                       maintenance: '/maintenance',
                       masters: '/masters/equipment-categories',
                       payments: '/payments',
+                      users: '/users',
                     };
                     navigate(paths[tab.id] || '/');
 
@@ -164,6 +176,9 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
                       case 'masters':
                         refreshEqCategories();
                         refreshPaymentPlans();
+                        break;
+                      case 'users':
+                        refreshUsers();
                         break;
                       case 'maintenance':
                         refreshMaintenanceRecords();
@@ -229,6 +244,9 @@ const Dashboard: React.FC<DashboardProps> = ({ sidebarOpen, setSidebarOpen }) =>
               return (
                 <MaintenanceTab navigateToEquipmentDetail={handleNavigateToEquipmentDetail} />
               );
+            }
+            if (activeTab === 'users' && isUsersBase) {
+              return <UsersTab />;
             }
             if (activeTab === 'payments' && isPaymentsBase) {
               return <PaymentsTab />;

--- a/src/components/dashboard/UsersTab.tsx
+++ b/src/components/dashboard/UsersTab.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useUsers } from '../../context/UserContext';
+import UserList from '../users/UserList';
+import SearchBox from '../ui/SearchBox';
+
+const UsersTab: React.FC = () => {
+  const { searchQuery, setSearchQuery } = useUsers();
+
+  return (
+    <>
+      <div className="mb-6 md:flex md:items-center md:justify-between">
+        <div className="w-full md:max-w-xs mb-4 md:mb-0">
+          <SearchBox value={searchQuery} onChange={setSearchQuery} placeholder="Search users..." />
+        </div>
+      </div>
+      <UserList />
+    </>
+  );
+};
+
+export default UsersTab;

--- a/src/components/users/UserList.tsx
+++ b/src/components/users/UserList.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useUsers } from '../../context/UserContext';
+import Spinner from '../ui/Spinner';
+import Pagination from '../ui/Pagination';
+import EmptyState from '../ui/EmptyState';
+import ErrorDisplay from '../ui/ErrorDisplay';
+import { Users as UsersIcon } from 'lucide-react';
+
+const UserList: React.FC = () => {
+  const {
+    users,
+    loading,
+    error,
+    totalUsers,
+    currentPage,
+    fetchUsersPage,
+    refreshUsers,
+  } = useUsers();
+
+  const recordsPerPage = 10;
+  const totalPages = Math.ceil(totalUsers / recordsPerPage);
+
+  if (loading && users.length === 0) {
+    return <div className="flex justify-center items-center h-64"><Spinner size="lg" /></div>;
+  }
+
+  if (error) {
+    return <ErrorDisplay message={error} onRetry={refreshUsers} />;
+  }
+
+  if (users.length === 0) {
+    return (
+      <EmptyState
+        title="No Users Found"
+        message="No users available."
+        icon={<UsersIcon className="w-16 h-16 text-gray-400" />}
+      />
+    );
+  }
+
+  return (
+    <div className="bg-white shadow-md rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-light-gray-200">
+          <thead className="bg-light-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">ID</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Username</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Name</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Email</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Role</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-dark-text uppercase tracking-wider">Status</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-light-gray-200">
+            {users.map(user => (
+              <tr key={user.user_id} className="hover:bg-light-gray-50 transition-colors">
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text font-medium">{user.user_id}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">{user.username}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">{user.first_name} {user.last_name}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">{user.email}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">{user.role || <span className="italic text-gray-400">N/A</span>}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-dark-text/80">{user.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {loading && users.length > 0 && (
+        <div className="my-4 flex justify-center"><Spinner size="md" /></div>
+      )}
+      {totalPages > 1 && (
+        <div className="p-4 border-t border-light-gray-200">
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={fetchUsersPage} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserList;

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,134 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
+import { User, PaginationParams, ApiResponse } from '../types';
+import { fetchUsers, searchUsers } from '../services/api/users';
+
+interface UserContextType {
+  users: User[];
+  loading: boolean;
+  error: string | null;
+  totalUsers: number;
+  currentPage: number;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  fetchUsersPage: (page: number) => void;
+  refreshUsers: () => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const useUsers = () => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUsers must be used within a UserProvider');
+  }
+  return context;
+};
+
+interface UserProviderProps {
+  children: ReactNode;
+  recordsPerPage?: number;
+}
+
+export const UserProvider: React.FC<UserProviderProps> = ({ children, recordsPerPage = 10 }) => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [totalUsers, setTotalUsers] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchQuery, setSearchQueryState] = useState('');
+  const [initialLoadDone, setInitialLoadDone] = useState(false);
+
+  const processApiResponse = (response: ApiResponse, page: number, currentSkip: number) => {
+    if (response.success && Array.isArray(response.data)) {
+      setUsers(response.data as User[]);
+      const apiTotal = response.totalRecords;
+      if (typeof apiTotal === 'number') {
+        setTotalUsers(apiTotal);
+      } else {
+        const newTotal = currentSkip + response.data.length + (response.data.length < recordsPerPage ? 0 : recordsPerPage);
+        setTotalUsers(prev => Math.max(prev, newTotal, response.data.length));
+      }
+      setCurrentPage(page);
+    } else if (response.success && !Array.isArray(response.data)) {
+      setError('Unexpected data format for users list.');
+      setUsers([]);
+      setTotalUsers(0);
+    } else {
+      setError(response.message || 'Unable to fetch users.');
+      if (users.length === 0) {
+        setUsers([]);
+        setTotalUsers(0);
+      }
+    }
+  };
+
+  const fetchUsersData = useCallback(async (page: number, query: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const skip = (page - 1) * recordsPerPage;
+      let response: ApiResponse;
+      const params: PaginationParams = { records: recordsPerPage, skip };
+      if (query.trim()) {
+        response = await searchUsers(query.trim(), params);
+      } else {
+        response = await fetchUsers(params);
+      }
+      processApiResponse(response, page, skip);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+      setError(message);
+      if (users.length === 0) {
+        setUsers([]);
+        setTotalUsers(0);
+      }
+    } finally {
+      setLoading(false);
+      if (page === 1 && !query.trim()) {
+        setInitialLoadDone(true);
+      }
+    }
+  }, [recordsPerPage, users.length]);
+
+  const setSearchQuery = (query: string) => {
+    setSearchQueryState(query);
+    setCurrentPage(1);
+    setInitialLoadDone(false);
+  };
+
+  useEffect(() => {
+    if (!searchQuery.trim() && !initialLoadDone && !loading) {
+      fetchUsersData(1, '');
+    }
+  }, [searchQuery, initialLoadDone, loading, fetchUsersData]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (searchQuery.trim()) {
+        fetchUsersData(1, searchQuery.trim());
+      }
+    }, 700);
+    return () => clearTimeout(handler);
+  }, [searchQuery, fetchUsersData]);
+
+  const refreshUsers = () => {
+    if (currentPage === 1 && !searchQuery.trim()) {
+      setInitialLoadDone(false);
+    }
+    fetchUsersData(currentPage, searchQuery);
+  };
+
+  const value = {
+    users,
+    loading,
+    error,
+    totalUsers,
+    currentPage,
+    searchQuery,
+    setSearchQuery,
+    fetchUsersPage: (page: number) => fetchUsersData(page, searchQuery),
+    refreshUsers,
+  };
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};

--- a/src/services/api/users.ts
+++ b/src/services/api/users.ts
@@ -1,0 +1,34 @@
+import { ApiResponse, PaginationParams } from '../../types';
+import { fetchFromApi } from './core';
+
+const TABLE = 'users1';
+
+export const fetchUsers = (params: PaginationParams): Promise<ApiResponse> => {
+  const apiParams: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    records: params.records,
+    skip: params.skip,
+    include_meta: 1,
+  };
+  if (params.q) apiParams.q = params.q;
+  return fetchFromApi('GET', apiParams);
+};
+
+export const searchUsers = (
+  queryValue: string,
+  paginationParams?: PaginationParams
+): Promise<ApiResponse> => {
+  const params: Record<string, any> = {
+    action: 'list',
+    table: TABLE,
+    qs: queryValue,
+    include_meta: 1,
+  };
+  if (paginationParams) {
+    params.records = paginationParams.records;
+    params.skip = paginationParams.skip;
+    if (paginationParams.q) params.q = paginationParams.q;
+  }
+  return fetchFromApi('GET', params);
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,22 @@ export interface PaymentFormData {
   notes?: string | null;
 }
 
+// --- User Types ---
+export interface User {
+  user_id: string;
+  username: string;
+  password_hash: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  role: string | null;
+  status: string;
+  created_at: string;
+  last_login: string | null;
+  apikey: string;
+}
+
+
 // --- Existing Maintenance Record Types ---
 export interface MaintenanceRecord {
   maintenance_id: number;


### PR DESCRIPTION
## Summary
- implement `users` API service and context
- render users table and add `Users` tab
- wire up new tab in `Dashboard` and router

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842a1fb8dec8321af849557892ac22e